### PR TITLE
Using same version of preact for pre-rendering

### DIFF
--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -1,6 +1,6 @@
 const { red, yellow } = require('kleur');
 const { resolve } = require('path');
-const { readFileSync } = require('fs');
+const { readFileSync, existsSync } = require('fs');
 const stackTrace = require('stack-trace');
 const { SourceMapConsumer } = require('source-map');
 
@@ -24,10 +24,15 @@ module.exports = function(env, params) {
 			);
 			return '';
 		}
-
-		let preact = require('preact'),
-			renderToString = require('preact-render-to-string');
-
+		const { cwd } = env;
+		const preactPath = require.resolve(`${cwd}/node_modules/preact`);
+		const renderToStringPath = require.resolve(
+			`${cwd}/node_modules/preact-render-to-string`
+		);
+		let preact = require(preactPath),
+			renderToString = require(existsSync(renderToStringPath)
+				? renderToStringPath
+				: 'preact-render-to-string');
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
 		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];

--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -1,6 +1,6 @@
 const { red, yellow } = require('kleur');
 const { resolve } = require('path');
-const { readFileSync, existsSync } = require('fs');
+const { readFileSync } = require('fs');
 const stackTrace = require('stack-trace');
 const { SourceMapConsumer } = require('source-map');
 
@@ -25,14 +25,10 @@ module.exports = function(env, params) {
 			return '';
 		}
 		const { cwd } = env;
-		const preactPath = require.resolve(`${cwd}/node_modules/preact`);
-		const renderToStringPath = require.resolve(
-			`${cwd}/node_modules/preact-render-to-string`
-		);
-		let preact = require(preactPath),
-			renderToString = require(existsSync(renderToStringPath)
-				? renderToStringPath
-				: 'preact-render-to-string');
+		let preact = require(require.resolve(`${cwd}/node_modules/preact`)),
+			renderToString = require(require.resolve(
+				`${cwd}/node_modules/preact-render-to-string`
+			));
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
 		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];

--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -25,10 +25,12 @@ module.exports = function(env, params) {
 			return '';
 		}
 		const { cwd } = env;
-		let preact = require(require.resolve(`${cwd}/node_modules/preact`)),
-			renderToString = require(require.resolve(
-				`${cwd}/node_modules/preact-render-to-string`
-			));
+
+		const preact = require(require.resolve(`${cwd}/node_modules/preact`));
+		const renderToString = require(require.resolve(
+			`${cwd}/node_modules/preact-render-to-string`
+		));
+
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
 		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];

--- a/packages/cli/lib/lib/webpack/webpack-server-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-server-config.js
@@ -15,11 +15,7 @@ function serverConfig(env) {
 			libraryTarget: 'commonjs2',
 		},
 		externals: {
-			/** This makes pre-rendered bundle use the same preact as preact-cli.
-			 * This is needed for the options object of preact-x.
-			 * Note: This means any upgrade of preact in user land will not affect pre-rendered bundle.
-			 */
-			preact: require.resolve('preact'),
+			preact: 'preact',
 		},
 		target: 'node',
 		resolveLoader: {

--- a/packages/cli/lib/lib/webpack/webpack-server-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-server-config.js
@@ -14,6 +14,9 @@ function serverConfig(env) {
 			chunkFilename: '[name].chunk.[chunkhash:5].js',
 			libraryTarget: 'commonjs2',
 		},
+		externals: {
+			preact: require.resolve('preact'),
+		},
 		target: 'node',
 		resolveLoader: {
 			alias: {

--- a/packages/cli/lib/lib/webpack/webpack-server-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-server-config.js
@@ -15,6 +15,10 @@ function serverConfig(env) {
 			libraryTarget: 'commonjs2',
 		},
 		externals: {
+			/** This makes pre-rendered bundle use the same preact as preact-cli.
+			 * This is needed for the options object of preact-x.
+			 * Note: This means any upgrade of preact in user land will not affect pre-rendered bundle.
+			 */
 			preact: require.resolve('preact'),
 		},
 		target: 'node',


### PR DESCRIPTION
Fixes #795 

**What kind of change does this PR introduce?**
Fixes duplicate preact problem.

- Uses `preact` . and `preact-render-to-string` from user land.
- Fall back to local `preact-render-to-string` to local copy but wont work with preact-X
- **Note:** After this we need to include `preact-render-to-string` in all our template's `package.json`

**Did you add tests for your changes?**
Already exist

**Does this PR introduce a breaking change?**
No
