### PR TITLE
Include readme in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "pretest": "yarn lint",
     "test": "lerna run test --stream",
     "prettier": "prettier --write **/*.{js,ts,tsx,json,css,scss,md,yml}",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepack": "cp README.md packages/cli/",
+    "postpack": "rm packages/cli/README.md"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "lerna run test --stream",
     "prettier": "prettier --write **/*.{js,ts,tsx,json,css,scss,md,yml}",
     "lint": "eslint .",
-    "prepack": "cp README.md packages/cli/",
-    "postpack": "rm packages/cli/README.md"
+    "prepack": "ncp README.md packages/cli/",
+    "postpack": "rimraf packages/cli/README.md"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
@@ -21,7 +21,9 @@
     "husky": "^2.3.0",
     "lerna": "^3.14.1",
     "lint-staged": "^8.1.7",
-    "prettier": "^1.17.1"
+    "ncp": "^2.0.0",
+    "prettier": "^1.17.1",
+    "rimraf": "^2.6.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Currently it's not included, since the readme is in the repo root.
I wasn't sure if the publishing process happens from within `packages/cli` or the root.
https://www.npmjs.com/package/preact-cli/v/3.0.0-rc.2