### PR TITLE
Fix issue with not using custom sw.js even if recognized

### DIFF
--- a/packages/cli/lib/lib/webpack/sw-plugin.js
+++ b/packages/cli/lib/lib/webpack/sw-plugin.js
@@ -15,13 +15,12 @@ class SWBuilderPlugin {
 		let swSrc = resolve(__dirname, '../sw.js');
 		const exists = fs.existsSync(resolve(`${this.src_}/sw.js`));
 		if (exists) {
-			if (exists) {
-				info(
-					'⚛️ Detected custom sw.js: compiling instead of default Service Worker.'
-				);
-			} else {
-				info('⚛️ No custom sw.js detected: compiling default Service Worker.');
-			}
+			swSrc = resolve(`${this.src_}/sw.js`);
+			info(
+				'⚛️ Detected custom sw.js: compiling instead of default Service Worker.'
+			);
+		} else {
+			info('⚛️ No custom sw.js detected: compiling default Service Worker.');
 		}
 		compiler.hooks.make.tapAsync(
 			this.constructor.name,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, not sure how to write tests for it so if someone could help me it'd be great.

**Summary**
When providing a custom sw.js in _/src/sw.js_ or _/sw.js_ the console log said "Detected custom sw.js: compiling instead of default Service Worker." but didn't actually use that file, instead always using the default sw.js.

There was also a redundant if statement (`if (exists) { if (exists) {`)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A
<!-- Node version, npm version, CLI version, operating system, browser -->
