### PR TITLE
ServiceWorker / Workbox Tweaks

### DIFF
--- a/packages/cli/lib/lib/sw.js
+++ b/packages/cli/lib/lib/sw.js
@@ -9,8 +9,8 @@ self.__precacheManifest = [].concat(self.__precacheManifest || []);
 if (process.env.ENABLE_BROTLI && process.env.ES_BUILD) {
 	// Alter the precache manifest to precache brotli files instead of gzip files.
 	self.__precacheManifest = self.__precacheManifest.map(asset => {
-		if (/.*.js$/.test(asset.url)) {
-			asset.url = asset.url.replace(/.esm.js$/, '.esm.js.br');
+		if (/\.js$/.test(asset.url)) {
+			asset.url = asset.url.replace(/\.esm\.js$/, '.esm.js.br');
 		}
 		return asset;
 	});
@@ -19,7 +19,7 @@ if (process.env.ENABLE_BROTLI && process.env.ES_BUILD) {
 		// Before saving the response in cache, we need to treat the headers.
 		async cacheWillUpdate({ response }) {
 			const clonedResponse = response.clone();
-			if (/.js.br(\?.*)?$/.test(clonedResponse.url)) {
+			if (/\.js\.br(\?.*)?$/.test(clonedResponse.url)) {
 				const headers = new Headers(clonedResponse.headers);
 				headers.set('content-type', 'application/javascript');
 				return new Response(await clonedResponse.text(), { headers });
@@ -33,8 +33,8 @@ if (process.env.ENABLE_BROTLI && process.env.ES_BUILD) {
 const precacheOptions = {};
 if (process.env.ENABLE_BROTLI) {
 	precacheOptions['urlManipulation'] = ({ url }) => {
-		if (/.esm.js$/.test(url.href)) {
-			url.href = url.href + '.br';
+		if (/\.esm\.js$/.test(url.href)) {
+			url.href += '.br';
 		}
 		return [url];
 	};

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -260,7 +260,7 @@ function isProd(config) {
 			prodConfig.plugins.push(
 				new InjectManifest({
 					swSrc: 'sw-esm.js',
-					include: [/index\.html$/, /\.esm.js$/, /\.css$/, /\.(png|jpg)$/],
+					include: [/^\/?index\.html$/, /\.esm.js$/, /\.css$/, /\.(png|jpg)$/],
 					precacheManifestFilename: 'precache-manifest.[manifestHash].esm.js',
 				})
 			);


### PR DESCRIPTION
Just a couple of tweaks:

- fixed a few regexes that were missing escapes (they'd match `foobarjs` as if it were a JS file)
- only precache the index route, since all navigation requests get routed to it once the SW has booted.