### PR TITLE
Respect browserslist configurations

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -4,6 +4,7 @@ const { resolve } = require('path');
 const { readFileSync, existsSync } = require('fs');
 const SizePlugin = require('size-plugin');
 const autoprefixer = require('autoprefixer');
+const browserslist = require('browserslist');
 const requireRelative = require('require-relative');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
@@ -64,7 +65,15 @@ module.exports = function(env) {
 	env.pkg = readJson(resolve(cwd, 'package.json')) || {};
 
 	let babelrc = readJson(resolve(cwd, 'old')) || {};
-	let browsers = env.pkg.browserslist || ['> 0.25%', 'IE >= 9'];
+
+	// use browserslist config environment, config default, or default browsers
+	// default browsers are > 0.25% global market share or Internet Explorer >= 9
+	const browserslistDefaults = ['> 0.25%', 'IE >= 9'];
+	const browserlistConfig = Object(browserslist.findConfig(cwd));
+	const browsers =
+		(isProd ? browserlistConfig.production : browserlistConfig.development) ||
+		browserlistConfig.default ||
+		browserslistDefaults;
 
 	let userNodeModules = findAllNodeModules(cwd);
 	let cliNodeModules = findAllNodeModules(__dirname);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,6 +80,7 @@
     "babel-plugin-macros": "^2.5.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "brotli-webpack-plugin": "^1.0.0",
+    "browserslist": "^4.6.4",
     "console-clear": "^1.0.0",
     "copy-webpack-plugin": "^5.0.3",
     "critters-webpack-plugin": "^1.3.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

1. This removes manual browserslist configuration detection, allowing browserslist to manage its own configurations.
2. This change also adds support for all browserslist configuration files. See https://github.com/browserslist/browserslist#config-file
3. This change also adds support for environment configurations, which would have been previously breaking to Preact CLI, even when done within package.json. See https://github.com/browserslist/browserslist#configuring-for-different-environments

**Did you add tests for your changes?**

No, this does not add tests, and there were no browserslist tests previously. Also, adding breaking browserslist configurations for the current release would only be useful if this project continues to manually check for configurations, which this change removes. Also, testing browserslist configurations could be problematic, as browserslist-enabled tooling within Babel and PostCSS would frequently change output as polyfills are updated and global usage stats change.

**Summary**

I looked into this codebase to see why our `.browserslistrc` file was not being respected.
I saw the excellent work in https://github.com/preactjs/preact-cli/pull/125 and decided to bring it that effort further into alignment with browserslist with this PR.

**Does this PR introduce a breaking change?**

No, this does not introduce a breaking change.

**Other information**

This adds a `browserslist` dependency, but it should de-dupe along with the other nested `browserslist` dependencies. See these results for `nom ls browserslist`:

```
preact-cli@3.0.0-rc.2 /preactjs/preact-cli/packages/cli
├─┬ @babel/preset-env@7.5.0
│ ├── browserslist@4.6.4  deduped
│ └─┬ core-js-compat@3.1.4
│   └── browserslist@4.6.4  deduped
├─┬ autoprefixer@9.6.1
│ └── browserslist@4.6.4  deduped
├── browserslist@4.6.4 
└─┬ optimize-css-assets-webpack-plugin@5.0.3
  └─┬ cssnano@4.1.10
    └─┬ cssnano-preset-default@4.0.7
      ├─┬ postcss-colormin@4.0.3
      │ └── browserslist@4.6.4  deduped
      ├─┬ postcss-merge-longhand@4.0.11
      │ └─┬ stylehacks@4.0.3
      │   └── browserslist@4.6.4  deduped
      ├─┬ postcss-merge-rules@4.0.3
      │ ├── browserslist@4.6.4  deduped
      │ └─┬ caniuse-api@3.0.0
      │   └── browserslist@4.6.4  deduped
      ├─┬ postcss-minify-params@4.0.2
      │ └── browserslist@4.6.4  deduped
      ├─┬ postcss-normalize-unicode@4.0.1
      │ └── browserslist@4.6.4  deduped
      └─┬ postcss-reduce-initial@4.0.3
        └── browserslist@4.6.4  deduped
```