### PR TITLE
Always enable CSS sourcemaps

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -210,7 +210,7 @@ module.exports = function(env) {
 								modules: true,
 								localIdentName: '[local]__[hash:base64:5]',
 								importLoaders: 1,
-								sourceMap: isProd,
+								sourceMap: true,
 							},
 						},
 						{
@@ -232,7 +232,7 @@ module.exports = function(env) {
 						{
 							loader: 'css-loader',
 							options: {
-								sourceMap: isProd,
+								sourceMap: true,
 							},
 						},
 						{

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -203,7 +203,14 @@ module.exports = function(env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					include: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						isWatch
+							? {
+									loader: 'style-loader',
+									options: {
+										sourceMap: true,
+									},
+							  }
+							: MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {
@@ -228,7 +235,14 @@ module.exports = function(env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					exclude: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						isWatch
+							? {
+									loader: 'style-loader',
+									options: {
+										sourceMap: true,
+									},
+							  }
+							: MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This change allows CSS source maps to be generated in development.

The current behavior is that CSS source maps are **not** generated in development. This PR changes that because source maps are intended to improve the _development_ experience. They are most often leveraged by _Developer_ Tools to make it “_much easier to debug the original source, rather than the source in the transformed state that the browser has downloaded_” ([mdn](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map)).

Admittedly, I would need to understand the rationale for the current behavior to be sure of this change. The current behavior is that CSS source maps are generated in production _only_. This seems odd to me, because I’ve understood production to be when smaller file sizes are more desirable, and debugging features are more often removed — for instance this project removes prototype debugging in production (https://github.com/preactjs/preact-cli/blob/master/packages/cli/lib/lib/babel-config.js#L30-L31).

**Did you add tests for your changes?**

No, the current source map behavior is also not tested.

**Summary**

I was excited to use CSS Modules, but found it difficult to debug in development without source maps.

**Does this PR introduce a breaking change?**

No, this does not introduce a breaking change.