### PR TITLE
Support pcss stylesheets

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -97,6 +97,7 @@ module.exports = function(env) {
 				'.tsx',
 				'.json',
 				'.less',
+				'.pcss',
 				'.scss',
 				'.sass',
 				'.styl',
@@ -190,7 +191,7 @@ module.exports = function(env) {
 				},
 				{
 					// User styles
-					test: /\.(css|less|s[ac]ss|styl)$/,
+					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					include: [source('components'), source('routes')],
 					use: [
 						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
@@ -215,7 +216,7 @@ module.exports = function(env) {
 				},
 				{
 					// External / `node_module` styles
-					test: /\.(css|less|s[ac]ss|styl)$/,
+					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					exclude: [source('components'), source('routes')],
 					use: [
 						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This change allows `.pcss` files to be used in projects. The **pcss** file extension is used for CSS files with loosely-compatible or non-W3C-standard features and enhancements, such as custom rules, custom selectors, custom functions, custom declarations, etc. These non-standard enhancements are typically associated with and processed by **PostCSS**.

See:
- https://github.com/github/linguist and specifically https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L3827-L3834
   - This is the library used by GitHub.com to detect all code types, generate language breakdowns, and facilitate syntax highlighting.
- https://plugins.jetbrains.com/plugin/8578-postcss and specifically https://github.com/JetBrains/intellij-plugins/blob/4481281dcdeee5db6cf6909ce302021716b0f0a7/postcss/src/org/intellij/plugins/postcss/PostCssFileType.java#L17
   - This is the official plugin for the syntax highlighting of custom and modern CSS syntaxes in IntelliJ IDEA, AppCode, CLion, GoLand, PhpStorm, PyCharm, Rider, RubyMine, and WebStorm.
- https://marketplace.visualstudio.com/items?itemName=ricard.PostCSS and specifically https://github.com/rcsole/postcss-syntax/blob/master/package.json#L26
   - This is the most popular plugin for the syntax highlighting of custom and modern CSS syntaxes in VSCode.


**Did you add tests for your changes?**

No, I did not add tests for this change, and there are no other tests currently for CSS file extensions.

**Summary**

Some projects prefer the **pcss** file extension for CSS files that require transformation to work in any browser, similar to how some projects prefer the **jsx** file extension for JS files requiring JSX transformation to work in any browser.

**Does this PR introduce a breaking change?**

No, this PR does not introduce a breaking change.