### PR TITLE
Support PostCSS plugin configuration

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -11,6 +11,7 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const ReplacePlugin = require('webpack-plugin-replace');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const createBabelConfig = require('../babel-config');
+const loadPostcssConfig = require('postcss-load-config');
 
 function readJson(file) {
 	try {
@@ -83,6 +84,14 @@ module.exports = function(env) {
 	);
 
 	let tsconfig = resolveTsconfig(cwd, isProd);
+
+	let postcssPlugins;
+
+	try {
+		postcssPlugins = loadPostcssConfig.sync(cwd).plugins;
+	} catch (error) {
+		postcssPlugins = [autoprefixer({ overrideBrowserslist: browsers })];
+	}
 
 	return {
 		context: src,
@@ -208,7 +217,7 @@ module.exports = function(env) {
 							options: {
 								ident: 'postcss',
 								sourceMap: true,
-								plugins: [autoprefixer({ overrideBrowserslist: browsers })],
+								plugins: postcssPlugins,
 							},
 						},
 					],
@@ -230,7 +239,7 @@ module.exports = function(env) {
 							options: {
 								ident: 'postcss',
 								sourceMap: true,
-								plugins: [autoprefixer({ overrideBrowserslist: browsers })],
+								plugins: postcssPlugins,
 							},
 						},
 					],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,6 +104,7 @@
     "minimatch": "^3.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "ora": "^3.4.0",
+    "postcss-load-config": "^2.1.0",
     "postcss-loader": "^3.0.0",
     "progress-bar-webpack-plugin": "^1.12.1",
     "promise-polyfill": "^8.1.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This change allows [the existing PostCSS Loader](https://github.com/preactjs/preact-cli/blob/v3.0.0-rc.2/packages/cli/lib/lib/webpack/webpack-base-config.js#L206-L213) to respect userland `postcss.config.js` configuration files in their ability to define the PostCSS plugins used in a project.

See https://github.com/postcss/postcss-loader#usage

**Did you add tests for your changes?**

No, and I did not see similar tests for PostCSS plugins in the existing project.

**Summary**

I would like to use [PostCSS Normalize](https://github.com/csstools/postcss-normalize) and [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env), but I am unable to do this in my `postcss.config.js` configuration file due to how **PostCSS Loader** is currently configured.

My workaround has been to detect and delete the existing **PostCSS Loader** `plugins` option, which then allows the configuration file to be followed. However, I think it would be better if the zero-configuration (i.e Autoprefixer) is preserved _unless_ a configuration file explicitly defines its own plugins.

**Does this PR introduce a breaking change?**

No, this PR does not introduce a breaking change.

**Other information**

This change adds a `postcss-load-config` dependency, but it should de-dupe along with the other nested `postcss-load-config` dependency. See these results for `npm ls postcss-load-config`:

```
preact-cli@3.0.0-rc.2 /preactjs/preact-cli/packages/cli
├── postcss-load-config@2.1.0 
└─┬ postcss-loader@3.0.0
  └── postcss-load-config@2.1.0  deduped
```