### PR TITLE
Use nomodule to conditionally load fetch+promise

### DIFF
--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -23,17 +23,17 @@
 		<%= htmlWebpackPlugin.options.ssr() %>
 		<% if (webpack.assets.filter(entry => entry.name.match(/bundle(\.\w{5})?.esm.js$/)).length > 0) { %>
 			<% /* Fix for safari < 11 nomodule bug. TODO: Do the following only for safari. */ %>
-			<script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
+			<script nomodule>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
 			<script crossorigin="anonymous" src="<%= htmlWebpackPlugin.files.publicPath %><%= webpack.assets.filter(entry => entry.name.match(/bundle(\.\w{5})?.esm.js$/))[0].name %>" type="module"></script>
 			<%
 				/*Fetch and Promise polyfills are not needed for browsers that support type=module
 				Please re-evaluate below line if adding more polyfills.*/
 			%>
-			<script nomodule>window.fetch||document.write('<script src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"><\/script>')</script>
+			<script nomodule src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"></script>
 			<script nomodule defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
 		<% } else { %>
 			<script <%= htmlWebpackPlugin.options.scriptLoading %>  src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
-			<script>window.fetch||document.write('<script src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"><\/script>')</script>
+			<script nomodule src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"></script>
 		<% } %>
 	</body>
 </html>


### PR DESCRIPTION
This switches from using `document.write()` for polyfill injection to using `<script nomodule>`.  It's not a perfect match, so it'll be loading fetch+Promise in Safari 10 where they're natively supported, but the performance benefits in other browsers seem worthwhile.