### PR TITLE
Fix hard to read cli label

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -278,7 +278,7 @@ module.exports = function(env) {
 			}),
 			new ProgressBarPlugin({
 				format:
-					'\u001b[90m\u001b[44mBuild\u001b[49m\u001b[39m [:bar] \u001b[32m\u001b[1m:percent\u001b[22m\u001b[39m (:elapseds) \u001b[2m:msg\u001b[22m',
+					'\u001b[37m\u001b[44m Build \u001b[49m\u001b[39m [:bar] \u001b[32m\u001b[1m:percent\u001b[22m\u001b[39m (:elapseds) \u001b[2m:msg\u001b[22m',
 				renderThrottle: 100,
 				summary: false,
 				clear: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR fixes a usability issue where the cli output was hard to read due to very low contrast. Previously we had a dark gray font on a blue background which is too close together on the brightness scale.

Also added a space around the label.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
not needed

**Summary**

It's best illustrated with a few screenshots. I'm using the default `Breeze` color scheme that ships with KDE.

Before:

![preact-cli-ascii-before](https://user-images.githubusercontent.com/1062408/61168455-c143f800-a54e-11e9-8daa-78d25d5dd952.png)

After:

![preact-cli-ascii-after](https://user-images.githubusercontent.com/1062408/61168457-c86b0600-a54e-11e9-9dde-991481c6f879.png)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->