### PR TITLE
Better service worker defaults

### DIFF
--- a/packages/cli/lib/lib/sw.js
+++ b/packages/cli/lib/lib/sw.js
@@ -48,7 +48,16 @@ const isNav = event => event.request.mode === 'navigate';
  */
 workbox.routing.registerRoute(
 	({ event }) => isNav(event),
-	new workbox.strategies.NetworkFirst()
+	new workbox.strategies.NetworkFirst({
+		// this cache is plunged with every new service worker deploy so we dont need to care about purging the cache.
+		cacheName: workbox.core.cacheNames.precache,
+		networkTimeoutSeconds: 5, // if u dont start getting headers within 5 sec fallback to cache.
+		plugins: [
+			new workbox.cacheableResponse.Plugin({
+				statuses: [200], // only cache valid responses, not opaque responses e.g. wifi portal.
+			}),
+		],
+	})
 );
 
 workbox.precaching.precacheAndRoute(self.__precacheManifest, precacheOptions);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
No. Opening a separate PR for puppeteer based tests.

**Summary**
- Adds a timeout for navigation request. i.e. After 5s if we don't get start getting response/headers, we'll fallback to cache
- Only cache `non opaque && 200-OK` responses

**Does this PR introduce a breaking change?**
No