### PR TITLE
Stop spinner during installation

### DIFF
--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -184,7 +184,8 @@ module.exports = async function(repo, dest, argv) {
 	// await fs.copyFile(serviceWorkerSrc, join(resolve(cwd, dest), 'src', 'sw.js'));
 
 	if (argv.install) {
-		spinner.text = 'Installing dependencies';
+		spinner.text = 'Installing dependencies:\n';
+		spinner.stopAndPersist();
 		await install(target, isYarn);
 	}
 


### PR DESCRIPTION
This allows npm and yarn to print their output to the cli.
Previously warnings and errors would be swallowed by the spinner

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
not needed

**Summary**
This PR stops the spinner during `npm/yarn install`. This allows the packager to forward messages to the parent process and respects custom formatting via carriage returns. Both currently supported packagers display their own spinner.

Originally I tried only passing warnings or errors to our process to allow us to keep using our own spinner. Trouble is that this would lead us down the rabbit whole of having to specifically parse each packager differently and be at the mercy of their output formatting. The hassle this would involve is just not worth it. So just stopping the spinner is the best solution for now in my opinion.

Here is what it looks like with this PR:

![preact-cli-output](https://user-images.githubusercontent.com/1062408/61868297-63fa6000-aed9-11e9-9173-d538145c51fa.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes #846 .

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->