### PR TITLE
Fix Promise polyfill not working in IE11

### DIFF
--- a/packages/cli/lib/lib/webpack/polyfills.js
+++ b/packages/cli/lib/lib/webpack/polyfills.js
@@ -1,2 +1,2 @@
-if (!global.Promise) global.Promise = require('promise-polyfill');
+if (!global.Promise) global.Promise = require('promise-polyfill').default;
 if (!global.fetch) global.fetch = require('isomorphic-unfetch');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, our tooling is not set up to run on other browsers than Chrome.

**Summary**

A bad import path for the `Promise` polyfill leads to an exception where the polyfill is used. Discovered this while work on fleshing out support for IE11 on [preact-www](https://github.com/preactjs/preact-www/pull/376). Instead of the expected `Promise` function we'd set `global.Promise` to the module object:

```js
// promise-polyfill.js
mode.exports = {
  default: function Promise() {}
};

// polyfills.js
global.Promise = require('promise-polyfill');
console.log(global.Promise);
// Logs: { default: [function Promise] }
```

So instead the `require` path call should be:

```js
global.Promise = require('promise-polyfill').default;
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
n/a