### PR TITLE
Project generation enhancements

### DIFF
--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -8,21 +8,21 @@ const { green } = require('kleur');
 const { resolve, join } = require('path');
 const { prompt } = require('prompts');
 const isValidName = require('validate-npm-package-name');
-const { info, isDir, hasCommand, error, trim, warn } = require('../util');
+const {
+	info,
+	isDir,
+	hasCommand,
+	error,
+	trim,
+	warn,
+	dirExists,
+} = require('../util');
 const { addScripts, install, initGit } = require('../lib/setup');
 
 const ORG = 'preactjs-templates';
 const RGX = /\.(woff2?|ttf|eot|jpe?g|ico|png|gif|webp|mp4|mov|ogg|webm)(\?.*)?$/i;
 const isMedia = str => RGX.test(str);
 const capitalize = str => str.charAt(0).toUpperCase() + str.substring(1);
-
-function directoryExists(workingDir, destDir) {
-	if (workingDir && destDir) {
-		const target = resolve(workingDir, destDir);
-		return isDir(target);
-	}
-	return false;
-}
 
 // Formulate Questions if `create` args are missing
 function requestParams(argv) {
@@ -80,8 +80,7 @@ function requestParams(argv) {
 			message: 'Directory to create the app',
 		},
 		{
-			type: prev =>
-				!directoryExists(cwd, prev || argv.dest) ? null : 'confirm',
+			type: prev => (!dirExists(cwd, prev || argv.dest) ? null : 'confirm'),
 			name: 'force',
 			message: 'The destination directory exists. Overwrite?',
 			initial: false,

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -222,12 +222,19 @@ module.exports = async function(repo, dest, argv) {
 
 	if (keeps.length) {
 		// eslint-disable-next-line
-		let dict = new Map();
+		const dict = new Map();
+		const templateVar = str => new RegExp(`{{\\s?${str}\\s}}`, 'g');
+
+		dict.set(templateVar('pkg-install'), isYarn ? 'yarn' : 'npm install');
+		dict.set(templateVar('pkg-run'), isYarn ? 'yarn' : 'npm run');
+		dict.set(templateVar('pkg-add'), isYarn ? 'yarn add' : 'npm install');
+		dict.set(templateVar('now-year'), new Date().getFullYear());
+
 		// TODO: concat author-driven patterns
 		['name'].forEach(str => {
 			// if value is defined
 			if (argv[str] !== void 0) {
-				dict.set(new RegExp(`{{\\s?${str}\\s}}`, 'g'), argv[str]);
+				dict.set(templateVar(str), argv[str]);
 			}
 		});
 		// Update each file's contents

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -228,6 +228,7 @@ module.exports = async function(repo, dest, argv) {
 		dict.set(templateVar('pkg-run'), isYarn ? 'yarn' : 'npm run');
 		dict.set(templateVar('pkg-add'), isYarn ? 'yarn add' : 'npm install');
 		dict.set(templateVar('now-year'), new Date().getFullYear());
+		dict.set(templateVar('license'), argv.license || 'MIT');
 
 		// TODO: concat author-driven patterns
 		['name'].forEach(str => {

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -61,11 +61,12 @@ prog
 	.describe('Create a new application')
 	.option('--name', 'The application name')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--force', 'Force destination output; will override!')
+	.option('--force', 'Force destination output; will override!', false)
 	.option('--install', 'Install dependencies', true)
-	.option('--yarn', 'Use `yarn` instead of `npm`')
-	.option('--git', 'Initialize git repository')
-	.option('-v, --verbose', 'Verbose output')
+	.option('--yarn', 'Use `yarn` instead of `npm`', false)
+	.option('--git', 'Initialize git repository', false)
+	.option('--license', 'License type', 'MIT')
+	.option('-v, --verbose', 'Verbose output', false)
 	.action(commands.create);
 
 prog

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -1,12 +1,23 @@
 const { blue, yellow, red } = require('kleur');
-const { normalize } = require('path');
+const { normalize, resolve } = require('path');
 const { statSync, existsSync } = require('fs');
 const symbols = require('./symbols');
 const which = require('which');
 
-exports.isDir = function(str) {
+function isDir(str) {
 	return existsSync(str) && statSync(str).isDirectory();
-};
+}
+
+function dirExits(workingDir, destDir) {
+	if (workingDir && destDir) {
+		const target = resolve(workingDir, destDir);
+		return isDir(target);
+	}
+	return false;
+}
+
+exports.isDir = isDir;
+exports.dirExists = dirExits;
 
 exports.hasCommand = function(str) {
 	return !!which.sync(str, { nothrow: true });

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -4,20 +4,17 @@ const { statSync, existsSync } = require('fs');
 const symbols = require('./symbols');
 const which = require('which');
 
-function isDir(str) {
+exports.isDir = function(str) {
 	return existsSync(str) && statSync(str).isDirectory();
-}
+};
 
-function dirExits(workingDir, destDir) {
+exports.dirExists = function(workingDir, destDir) {
 	if (workingDir && destDir) {
 		const target = resolve(workingDir, destDir);
-		return isDir(target);
+		return exports.isDir(target);
 	}
 	return false;
-}
-
-exports.isDir = isDir;
-exports.dirExists = dirExits;
+};
 
 exports.hasCommand = function(str) {
 	return !!which.sync(str, { nothrow: true });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no, manual tests only

**Summary**
Fixes #871 

* Adds missing default values for `preact create --help`
* Moves "dirExits" (create command) to the utils
* Adds support for `--license` option for `create` (defaults to `MIT`)
* Introduces support for additional template variables:
  * `{{ pkg-install }}` => `npm install` or `yarn`
  * `{{ pkg-run }}` => `npm run` or `yarn`
  * `{{ pkg-add }}` => `npm install` or `yarn add`
  * `{{ now-year }}` => current year
  * `{{ license }}` => license or `MIT`

Example for new options:

```sh
preact create default yarnapp --yarn --install=false --license=Apache
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
See also: https://github.com/preactjs-templates/default/pull/29

