### PR TITLE
Update README to specify version 7 of sass-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ The default templates comes with a `.css` file for each component. You can start
 
 #### [SASS]
 
-- `npm install --save-dev node-sass sass-loader` (inside your preact application folder)
+- `npm install --save-dev node-sass sass-loader@7` (inside your preact application folder)
 - start replacing `.css` files with `.scss` files
 
 #### [LESS]


### PR DESCRIPTION
The latest version of sass-loader is version 8, which is presently incompatible and causes the build to fail. Version 7 is compatible.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Documentation
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

**Summary**
Updates the README to prompt installation of sass-loader version 7. The latest version, 8, is incompatible with the build config.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Please paste the results of `preact info` here.
