### PR TITLE
Remove extraneous sourceMap option from style-loader

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -212,14 +212,7 @@ module.exports = function(env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					include: [source('components'), source('routes')],
 					use: [
-						isWatch
-							? {
-									loader: 'style-loader',
-									options: {
-										sourceMap: true,
-									},
-							  }
-							: MiniCssExtractPlugin.loader,
+						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {
@@ -245,14 +238,7 @@ module.exports = function(env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					exclude: [source('components'), source('routes')],
 					use: [
-						isWatch
-							? {
-									loader: 'style-loader',
-									options: {
-										sourceMap: true,
-									},
-							  }
-							: MiniCssExtractPlugin.loader,
+						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Preact-cli 3.0.0.RC.4 in dev mode failing with 

`ValidationError: Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.` due to sourceMap being included for `style-loader`

sourceMap not a valid option for `style-loader` https://github.com/webpack-contrib/style-loader#options


I've removed those config options for both user and external styles.

**Did you add tests for your changes?**

N/A

