### PR TITLE
Support all maintained node versions in jest-preset-preact

### DIFF
--- a/packages/jest-preset-preact/src/babel-jest.js
+++ b/packages/jest-preset-preact/src/babel-jest.js
@@ -3,7 +3,7 @@ const babelJest = require('babel-jest');
 
 const config = createConfig(
 	{ production: false },
-	{ modules: 'commonjs', browsers: 'node 10' }
+	{ modules: 'commonjs', browsers: 'maintained node versions' }
 );
 
 module.exports = babelJest.createTransformer({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no

**Summary**
Update babel-jest in jest-preset-preact to support all maintained node versions. I run into the problem because I use node 12. I needed to change the value to "maintained node versions". 

```shell
BrowserslistError: [BABEL] /test-preact/tests/header.test.js: Unknown browser node (While processing: "/test-preact/node_modules/babel-preset-env/lib/index.js")
at checkName (node_modules/babel-preset-env/node_modules/browserslist/index.js:112:20)
at Function.select (node_modules/babel-preset-env/node_modules/browserslist/index.js:675:18)
at node_modules/babel-preset-env/node_modules/browserslist/index.js:140:33
at Array.reduce (<anonymous>)
at resolve (node_modules/babel-preset-env/node_modules/browserslist/index.js:121:18)
at browserslist (node_modules/babel-preset-env/node_modules/browserslist/index.js:217:16)
at getTargets (node_modules/babel-preset-env/lib/targets-parser.js:103:63)
at buildPreset (node_modules/babel-preset-env/lib/index.js:144:45)
at node_modules/@babel/core/lib/config/full.js:167:14
at cachedFunction (node_modules/@babel/core/lib/config/caching.js:33:19)
````

 https://github.com/preactjs/preact-cli/issues/892#issuecomment-536818432

**Does this PR introduce a breaking change?**
no

**Other information**
Environment Info:
```shell
  System:
    OS: Linux 5.3 Arch Linux undefined
    CPU: (8) x64 Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
  Binaries:
    Node: 12.10.0 - ~/.nvm/versions/node/v12.10.0/bin/node
    Yarn: 1.17.3 - ~/.nvm/versions/node/v12.10.0/bin/yarn
    npm: 6.10.3 - ~/.nvm/versions/node/v12.10.0/bin/npm
  Browsers:
    Firefox: 69.0.1
  npmGlobalPackages:
    preact-cli: 3.0.0-rc.5
```


