### PR TITLE
.default -> .defaults

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -73,7 +73,7 @@ module.exports = function(env) {
 	const browserlistConfig = Object(browserslist.findConfig(cwd));
 	const browsers =
 		(isProd ? browserlistConfig.production : browserlistConfig.development) ||
-		browserlistConfig.default ||
+		browserlistConfig.defaults ||
 		browserslistDefaults;
 
 	let userNodeModules = findAllNodeModules(cwd);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
**Summary**
```js
//webpack-base-config.js

const browserlistConfig = Object(browserslist.findConfig(cwd));
const browsers =
	(isProd ? browserlistConfig.production : browserlistConfig.development) ||
		browserlistConfig.defaults ||
		browserslistDefaults;
```
the object returned from `browserslist.findConfig` contains the key `.defaults`, not `.default`. This invalid reference is causing `browsers` to always resolve to `browserslistDefaults` if neither `.production` or `.development` is found on `browserlistConfig`. I pass a custom `browserslist` config into my `package.json` that is never being used, given this bug.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Please paste the results of `preact info` here.
