### PR TITLE
fix watch exiting on build errors #939

### DIFF
--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -63,7 +63,7 @@ async function devBuild(env) {
 				process.stdout.write(`${bold('On Your Network:')}  ${localIpAddr}\n`);
 			}
 
-			showStats(stats);
+			showStats(stats, false);
 		});
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
@@ -95,13 +95,13 @@ async function prodBuild(env) {
 	// Timeout for plugins that work on `after-emit` event of webpack
 	await new Promise(r => setTimeout(r, 20));
 
-	return showStats(stats);
+	return showStats(stats, true);
 }
 
 function runCompiler(compiler) {
 	return new Promise((res, rej) => {
 		compiler.run((err, stats) => {
-			showStats(stats);
+			showStats(stats, true);
 
 			if (err || (stats && stats.hasErrors())) {
 				rej(red('Build failed! ' + (err || '')));
@@ -112,12 +112,12 @@ function runCompiler(compiler) {
 	});
 }
 
-function showStats(stats) {
+function showStats(stats, isProd) {
 	if (stats) {
 		if (stats.hasErrors()) {
 			allFields(stats, 'errors')
 				.map(stripLoaderPrefix)
-				.forEach(msg => error(msg));
+				.forEach(msg => error(msg, isProd ? 1 : 0));
 		}
 
 		if (stats.hasWarnings()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no

**Summary**
fix for https://github.com/preactjs/preact-cli/issues/939

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Please paste the results of `preact info` here.
  System:
    OS: macOS 10.14.6
    CPU: (8) x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  Binaries:
    Node: 10.16.3 - /usr/local/bin/node
    Yarn: 1.21.1 - /usr/local/bin/yarn
    npm: 6.11.3 - /usr/local/bin/npm
  Browsers:
    Chrome: 79.0.3945.117
    Safari: 13.0.4
  npmPackages:
    preact: ^10.0.0 => 10.0.0 
    preact-cli: 3.0.0-rc.4 => 3.0.0-rc.4 
    preact-render-to-string: ^5.0.7 => 5.0.7 
    preact-router: ^3.0.1 => 3.0.1 
  npmGlobalPackages:
    preact-cli: 3.0.0-rc.4

