### PR TITLE
Fix Lighthouse Audit warning: missing noscript block

### DIFF
--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -9,6 +9,7 @@
 		<% preact.headEnd %>
 	</head>
 	<body>
+		<noscript>JavaScript is required to use this webapp</noscript>
 		<% preact.bodyEnd %>
 	</body>
 </html>


### PR DESCRIPTION
Adds a noscript block to the body of the template, to inform visitors that javascript is required.
Fixes the warning in Lighthouse Audit:
https://web.dev/without-javascript/?utm_source=lighthouse&utm_medium=devtools
Placed in body to support html4 as well as html5
