### PR TITLE
Don't emit prerender data script if there is none

### DIFF
--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -93,7 +93,9 @@ module.exports = async function(config) {
 				return config.prerender ? prerender({ cwd, dest, src }, values) : '';
 			},
 			scriptLoading: 'defer',
-			CLI_DATA: { preRenderData: { url, ...routeData } },
+			CLI_DATA: Object.keys(routeData).length
+				? { preRenderData: { url, ...routeData } }
+				: undefined,
 		});
 	};
 


### PR DESCRIPTION
One thing I haven't checked yet: will this cause prerender-data-provider to attempt to fetch prerender data because there's no script tag?