### PR TITLE
falling back to legacy loader until we find a fix for preact X hydration

### DIFF
--- a/packages/async-loader/index.js
+++ b/packages/async-loader/index.js
@@ -2,7 +2,8 @@ const path = require('path');
 const { getOptions, stringifyRequest } = require('loader-utils');
 const PREACT_LEGACY_MODE = 'PREACT_LEGACY_MODE';
 
-exports.pitch = function(req, mode) {
+exports.pitch = function(req) {
+	//, mode) {
 	this.cacheable && this.cacheable();
 	let name;
 	let query = getOptions(this) || {};
@@ -23,7 +24,9 @@ exports.pitch = function(req, mode) {
 			this,
 			path.resolve(
 				__dirname,
-				mode === PREACT_LEGACY_MODE ? 'async-legacy.js' : 'async.js'
+				'async-legacy.js'
+				// to be re-enabled when we fix fix for preact X hydration.
+				//mode === PREACT_LEGACY_MODE ? 'async-legacy.js' : 'async.js'
 			) // explicit value check because webpack sends 2nd argument values but we dont use it
 		)};
 


### PR DESCRIPTION
- always uses legacy preact8 loader