### PR TITLE
chore: Log build errors

### DIFF
--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -109,7 +109,7 @@ function runCompiler(compiler) {
 			showStats(stats, true);
 
 			if (err || (stats && stats.hasErrors())) {
-				rej(red('\n\nBuild failed! \n\n' + (err || '')));
+				rej(`${red('\n\nBuild failed! \n\n')} ${err || ''}`);
 			}
 
 			res(stats);

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -90,12 +90,17 @@ async function prodBuild(env) {
 	}
 
 	let clientCompiler = webpack(config);
-	let stats = await runCompiler(clientCompiler);
 
-	// Timeout for plugins that work on `after-emit` event of webpack
-	await new Promise(r => setTimeout(r, 20));
+	try {
+		let stats = await runCompiler(clientCompiler);
 
-	return showStats(stats, true);
+		// Timeout for plugins that work on `after-emit` event of webpack
+		await new Promise(r => setTimeout(r, 20));
+
+		return showStats(stats, true);
+	} catch (error) {
+		console.log(error);
+	}
 }
 
 function runCompiler(compiler) {
@@ -104,7 +109,7 @@ function runCompiler(compiler) {
 			showStats(stats, true);
 
 			if (err || (stats && stats.hasErrors())) {
-				rej(red('Build failed! ' + (err || '')));
+				rej(red('\n\nBuild failed! \n\n' + (err || '')));
 			}
 
 			res(stats);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**Summary**
Till now whenever our build fails, we aren't logging the errors to the console. This PR adds a tryCatch block around the runCompiler instance where we get the errors thrown the promise.

Before:
<img width="647" alt="Screenshot 2020-03-06 at 3 45 42 PM" src="https://user-images.githubusercontent.com/3415488/76075241-a97c2100-5fc2-11ea-93d7-9793ec89da2c.png">

After:
<img width="1680" alt="Screenshot 2020-03-06 at 3 44 01 PM" src="https://user-images.githubusercontent.com/3415488/76075268-b4cf4c80-5fc2-11ea-9b3b-5273fa9bff60.png">

**Does this PR introduce a breaking change?**
Nope

**Other information**

Please paste the results of `preact info` here.
```
Environment Info:

  System:
    OS: macOS 10.15.3
    CPU: (8) x64 Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
  Binaries:
    Node: 12.16.1 - ~/.nvm/versions/node/v12.16.1/bin/node
    Yarn: 1.22.0 - /usr/local/bin/yarn
    npm: 6.13.4 - ~/.nvm/versions/node/v12.16.1/bin/npm
  Browsers:
    Chrome: 80.0.3987.132
    Firefox: 73.0.1
    Safari: 13.0.5
  npmPackages:
    preact: ^10.3.2 => 10.3.3
    preact-cli: ^3.0.0-rc.6 => 3.0.0-rc.9
    preact-render-to-string: ^5.1.4 => 5.1.4
    preact-router: ^3.2.1 => 3.2.1
```
