### PR TITLE
Power template list from github API in `preact create` command

### DIFF
--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -108,6 +108,11 @@ async function fetchTemplates() {
 			await fs.writeFile(TEMPLATES_CACHE_FILENAME, JSON.stringify(repos, null, 2), 'utf-8');
 		}
 
+		// fetch the API response from cache file
+		const templatesFromCache = await fs.readFile(TEMPLATES_CACHE_FILENAME, 'utf8');
+		const parsedTemplates = JSON.parse(templatesFromCache);
+		const officialTemplates = normalizeTemplatesResponse(parsedTemplates || []);
+
 		templates = officialTemplates.concat(CUSTOM_TEMPLATE);
 	} catch (e) {
 		// in case github API fails to fetch the data, fallback to the hard coded listings

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -95,6 +95,15 @@ function requestParams(argv, templates) {
 	];
 }
 
+async function updateTemplatesCache() {
+	const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
+	await fs.writeFile(
+		TEMPLATES_CACHE_FILENAME,
+		JSON.stringify(repos, null, 2),
+		'utf-8'
+	);
+}
+
 async function fetchTemplates() {
 	let templates = [];
 
@@ -113,15 +122,7 @@ async function fetchTemplates() {
 		}
 
 		// update the cache file without blocking the rest of the tasks.
-		fetch(TEMPLATES_REPO_URL)
-			.then(r => r.json())
-			.then(repos => {
-				fs.writeFile(
-					TEMPLATES_CACHE_FILENAME,
-					JSON.stringify(repos, null, 2),
-					'utf-8'
-				);
-			});
+		updateTemplatesCache();
 
 		// fetch the API response from cache file
 		const templatesFromCache = await fs.readFile(

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -1,5 +1,6 @@
 const ora = require('ora');
 const { promisify } = require('util');
+const fetch = require('isomorphic-unfetch');
 const glob = promisify(require('glob').glob);
 const gittar = require('gittar');
 const mkdirp = require('mkdirp');
@@ -16,7 +17,13 @@ const {
 	trim,
 	warn,
 	dirExists,
+	normalizeTemplatesResponse,
 } = require('../util');
+const {
+	TEMPLATES_REPO_URL,
+	CUSTOM_TEMPLATE,
+	FALLBACK_TEMPLATE_OPTIONS,
+} = require('../constants');
 const { addScripts, install, initGit } = require('../lib/setup');
 
 const ORG = 'preactjs-templates';
@@ -25,7 +32,7 @@ const isMedia = str => RGX.test(str);
 const capitalize = str => str.charAt(0).toUpperCase() + str.substring(1);
 
 // Formulate Questions if `create` args are missing
-function requestParams(argv) {
+function requestParams(argv, templates) {
 	const cwd = resolve(argv.cwd);
 
 	return [
@@ -34,39 +41,7 @@ function requestParams(argv) {
 			type: argv.template ? null : 'select',
 			name: 'template',
 			message: 'Pick a template',
-			choices: [
-				{
-					value: 'preactjs-templates/default',
-					title: 'Default (JavaScript)',
-					description: 'Default template with all features',
-				},
-				{
-					value: 'preactjs-templates/typescript',
-					title: 'Default (TypeScript)',
-					description: 'Default template with all features',
-				},
-				{
-					value: 'preactjs-templates/material',
-					title: 'Material',
-					description: 'Material template using preact-material-components',
-				},
-				{
-					value: 'preactjs-templates/simple',
-					title: 'Simple',
-					description: 'The simplest possible preact setup in a single file',
-				},
-				{
-					value: 'preactjs-templates/widget',
-					title: 'Widget',
-					description:
-						'Template for a widget to be embedded in another website',
-				},
-				{
-					value: 'custom',
-					title: 'Custom',
-					description: 'Use your own template',
-				},
-			],
+			choices: templates,
 			initial: 0,
 		},
 		{
@@ -119,10 +94,28 @@ function requestParams(argv) {
 	];
 }
 
+async function fetchTemplates() {
+	let templates = [];
+
+	try {
+		// fetch the repos list from the github API
+		const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
+		const officialTemplates = normalizeTemplatesResponse(repos || []);
+
+		templates = officialTemplates.concat(CUSTOM_TEMPLATE);
+	} catch (e) {
+		// in case github API fails to fetch the data, fallback to the hard coded listings
+		templates = FALLBACK_TEMPLATE_OPTIONS.concat(CUSTOM_TEMPLATE);
+	}
+
+	return templates;
+}
+
 module.exports = async function(repo, dest, argv) {
 	// Prompt if incomplete data
 	if (!repo || !dest) {
-		const questions = requestParams(argv);
+		const templates = await fetchTemplates();
+		const questions = requestParams(argv, templates);
 		const onCancel = () => {
 			info('Aborting execution');
 			process.exit();

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -99,6 +99,7 @@ async function fetchTemplates() {
 
 	try {
 		// fetch the repos list from the github API
+		info('\nFetching official templates:\n');
 		const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
 		const officialTemplates = normalizeTemplatesResponse(repos || []);
 

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -105,11 +105,29 @@ async function fetchTemplates() {
 		// If cache file doesn't exist, then hit the API and fetch the data
 		if (!fs.existsSync(TEMPLATES_CACHE_FILENAME)) {
 			const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
-			await fs.writeFile(TEMPLATES_CACHE_FILENAME, JSON.stringify(repos, null, 2), 'utf-8');
+			await fs.writeFile(
+				TEMPLATES_CACHE_FILENAME,
+				JSON.stringify(repos, null, 2),
+				'utf-8'
+			);
 		}
 
+		// update the cache file without blocking the rest of the tasks.
+		fetch(TEMPLATES_REPO_URL)
+			.then(r => r.json())
+			.then(repos => {
+				fs.writeFile(
+					TEMPLATES_CACHE_FILENAME,
+					JSON.stringify(repos, null, 2),
+					'utf-8'
+				);
+			});
+
 		// fetch the API response from cache file
-		const templatesFromCache = await fs.readFile(TEMPLATES_CACHE_FILENAME, 'utf8');
+		const templatesFromCache = await fs.readFile(
+			TEMPLATES_CACHE_FILENAME,
+			'utf8'
+		);
 		const parsedTemplates = JSON.parse(templatesFromCache);
 		const officialTemplates = normalizeTemplatesResponse(parsedTemplates || []);
 

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -20,8 +20,9 @@ const {
 	normalizeTemplatesResponse,
 } = require('../util');
 const {
-	TEMPLATES_REPO_URL,
 	CUSTOM_TEMPLATE,
+	TEMPLATES_REPO_URL,
+	TEMPLATES_CACHE_FILENAME,
 	FALLBACK_TEMPLATE_OPTIONS,
 } = require('../constants');
 const { addScripts, install, initGit } = require('../lib/setup');
@@ -99,9 +100,13 @@ async function fetchTemplates() {
 
 	try {
 		// fetch the repos list from the github API
-		info('\nFetching official templates:\n');
-		const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
-		const officialTemplates = normalizeTemplatesResponse(repos || []);
+		info('Fetching official templates:\n');
+
+		// If cache file doesn't exist, then hit the API and fetch the data
+		if (!fs.existsSync(TEMPLATES_CACHE_FILENAME)) {
+			const repos = await fetch(TEMPLATES_REPO_URL).then(r => r.json());
+			await fs.writeFile(TEMPLATES_CACHE_FILENAME, JSON.stringify(repos, null, 2), 'utf-8');
+		}
 
 		templates = officialTemplates.concat(CUSTOM_TEMPLATE);
 	} catch (e) {

--- a/packages/cli/lib/constants.js
+++ b/packages/cli/lib/constants.js
@@ -1,0 +1,41 @@
+exports.TEMPLATES_REPO_URL =
+	'https://api.github.com/users/preactjs-templates/repos';
+
+exports.CUSTOM_TEMPLATE = {
+	value: 'custom',
+	title: 'Custom',
+	description: 'Use your own template',
+};
+
+exports.FALLBACK_TEMPLATE_OPTIONS = [
+	{
+		value: 'preactjs-templates/default',
+		title: 'default',
+		description: 'The default template for Preact CLI',
+	},
+	{
+		value: 'preactjs-templates/typescript',
+		title: 'typescript',
+		description: 'The default template for Preact CLI in typescript',
+	},
+	{
+		value: 'preactjs-templates/material',
+		title: 'material',
+		description: 'The material design `preact-cli` template',
+	},
+	{
+		value: 'preactjs-templates/simple',
+		title: 'simple',
+		description: 'A simple, minimal "Hello World" template for Preact CLI',
+	},
+	{
+		value: 'preactjs-templates/netlify',
+		title: 'netlify',
+		description: 'A preactjs and netlify CMS template',
+	},
+	{
+		value: 'preactjs-templates/widget',
+		title: 'widget',
+		description: 'Template for a widget to be embedded in another website',
+	},
+];

--- a/packages/cli/lib/constants.js
+++ b/packages/cli/lib/constants.js
@@ -39,3 +39,5 @@ exports.FALLBACK_TEMPLATE_OPTIONS = [
 		description: 'Template for a widget to be embedded in another website',
 	},
 ];
+
+exports.TEMPLATES_CACHE_FILENAME = '.preact-templates.json';

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -42,3 +42,11 @@ exports.error = function(text, code = 1) {
 exports.normalizePath = function(str) {
 	return normalize(str).replace(/\\/g, '/');
 };
+
+exports.normalizeTemplatesResponse = function(repos = []) {
+	return repos.map(repo => ({
+		title: repo.name || '',
+		value: repo.full_name || '',
+		description: repo.description || '',
+	}));
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not required

**Summary**
Right now, we have hard coded the template choices for `create` command. With this PR, we fetch the listings from the github API (same API which we use for `preact list` command) and load the template options from static fallback values.

**Does this PR introduce a breaking change?**
Nope

Please paste the results of `preact info` here.
```
Environment Info:

  System:
    OS: macOS 10.15.3
    CPU: (8) x64 Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
  Binaries:
    Node: 12.16.1 - ~/.nvm/versions/node/v12.16.1/bin/node
    Yarn: 1.22.0 - /usr/local/bin/yarn
    npm: 6.13.4 - ~/.nvm/versions/node/v12.16.1/bin/npm
  Browsers:
    Chrome: 80.0.3987.132
    Firefox: 73.0.1
    Safari: 13.0.5
```