### PR TITLE
bugfix: Pass Array<String> to less-loader options.

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -183,7 +183,7 @@ module.exports = function (env) {
 								options: {
 									sourceMap: true,
 									lessOptions: {
-										paths: [nodeModules],
+										paths: [...nodeModules],
 									},
 								},
 							},


### PR DESCRIPTION
# Invalid options passed to `paths` property of `less-loader`.

## Description:

Importing a LESS stylesheet from `node_modules` throws an error during compilation.

```sh
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at validateString (internal/validators.js:112:11)
    at Object.join (path.js:1039:7)
    at tryPrefix ($HOME/preact-cli-test-less/node_modules/less/dist/less.cjs.js:211:53)
    at tryPathIndex ($HOME/preact-cli-test-less/node_modules/less/dist/less.cjs.js:270:23)
    at tryPrefix ($HOME/preact-cli-test-less/node_modules/less/dist/less.cjs.js:268:29)
    at ReadFileContext.<anonymous> ($HOME/preact-cli-test-less/node_modules/less/dist/less.cjs.js:260:48)
    at ReadFileContext.callback ($HOME/preact-cli-test-less/node_modules/graceful-fs/graceful-fs.js:115:16)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:239:13) {
```

## Root Cause

The `options.path` property of `less-loader` is being passed `Array<Array<String>>`, but expects `Array<String>`.

## Reproduction:

```sh
# Create a project with the default template.
npx preact-cli@rc create default preact-cli-test-less
cd preact-cli-test-less

# Install LESS
npm install --save-dev less less-loader@5

# Create a fake module with a LESS stylesheet in it.
mkdir node_modules/module-with-stylesheet
echo 'p { color: inherit }' > node_modules/module-with-stylesheet/index.less

# Import the stylesheet from the fake module.
mv src/style/index.css src/style/index.less
echo "@import 'module-with-stylesheet/index.less';" >> src/style/index.less

# Start the project and observe error.
npm run dev
```

## Workaround

The option can be fixed through custom configuration in `preact.config.js`:

```js
+ preact.config.js

export default (config, env, helpers) => {
  const rules = helpers.getRulesByMatchingFile(config, '.less');

  // Fix a preact-cli issue where LESS loader is passed an Array<Array<String>>
  // when it expects an Array<String>
  rules[0].rule.use[0].options.options.paths = rules[0].rule.use[0].options.options.paths[0];
};
```

## Fix

Instead of `Array<Array<String>>`, pass `Array<String>` to `less-loader` `options.path`.

----

Let me know what you think, or if I'm missing something entirely. Thanks!