### PR TITLE
Add "bugfixes: true" to preset-env in default Babel config

### DIFF
--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -18,6 +18,7 @@ module.exports = function(env, options = {}) {
 						browsers: options.browsers,
 					},
 					exclude: ['transform-regenerator', 'transform-async-to-generator'],
+        				bugfixes: true,
 				},
 			],
 		],


### PR DESCRIPTION
Seems like an easy win to get even smaller bundle sizes from @developit's recent addition to babel-preset-env as detailed here: https://babeljs.io/blog/2020/03/16/7.9.0

Checked package.json for the CLI package, it appears it's already been upgraded to the latest versions for babel.
