### PR TITLE
✏️ typo after bootstrapping from template

### DIFF
--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -372,7 +372,7 @@ module.exports = async function(repo, dest, argv) {
 			${green('cd ' + dest)}
 
 		To start a development live-reload server:
-			${green(pfx + ' start')}
+			${green(pfx + ' dev')}
 
 		To create a production build (in ./build):
 			${green(pfx + ' build')}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Just a small typo fixed 🙂
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**Summary**
after bootstrapping application from predefined template below is the output

```txt
harsh@nebula:~/git$ preact create typescript xyz
<clipped>
To start a development live-reload server:
  npm run start <----------------------------
<clipped>
```

it says `npm run start` but should be `npm run dev`  as we can see it in default template link below
- https://github.com/preactjs-templates/default/blob/master/template/package.json#L9
- https://github.com/preactjs-templates/typescript/blob/master/template/package.json#L9

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Nothing else just a typo

Please paste the results of `preact info` here.
```txt
         ▄▄
     ▄▄▓▓▓▓▓▓▄▄
  ▄█▀▀█▓▓▓▓▓▓▓▀▀█▄▄
▐▓▌▐▓▓▓▒▄ ▀▄▄▓▓▓▌▐▓▌ 
▐▓▓▄▀▓▀ ▄▓▓▄▄▀▓▓ ▓▓▌ 
▐▓▓▓▌ ▒▓▌  ▐▓▓  ▓▓▓▌ preact-cli 2.2.1
▐▓▓ ▒▓▄▄▀▓▓▀ ▄▓▓ ▓▓▌
▐▓▌▐▓▓▓▀▀▄▄▀▀▓▓▓▌▐▓▌
  ▀█▄▄▒▓▓▓▓▓▓▒▄▄▒▀
      ▀▓▓▓▓▓▓▀▀
         ▀▀
For help with a specific command, enter:
  preact help [command]

Commands:
  create [template] [dest]  Create a new application.
  build [src] [dest]        Create a production build in build/
  watch [src]               Start a development live-reload server.
  serve [dir]               Start an HTTP2 static fileserver.
  list                      List all official templates

Options:
  -h, --help  Show help                                                [boolean]

Unknown argument: info
```

