### PR TITLE
convert to @prefresh/webpack and use react-refresh/babel for hooks

### DIFF
--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -1,5 +1,5 @@
-module.exports = function(env, options = {}) {
-	const { production: isProd, rhl: isRHLEnabled } = env || {};
+module.exports = function (env, options = {}) {
+	const { production: isProd, rhl: isRHLEnabled, refresh } = env || {};
 
 	return {
 		presets: [
@@ -22,10 +22,14 @@ module.exports = function(env, options = {}) {
 			],
 		],
 		plugins: [
+			!isProd && refresh && require.resolve('react-refresh/babel'),
 			require.resolve('@babel/plugin-syntax-dynamic-import'),
 			require.resolve('@babel/plugin-transform-object-assign'),
 			[require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-			[require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+			[
+				require.resolve('@babel/plugin-proposal-class-properties'),
+				{ loose: true },
+			],
 			require.resolve('@babel/plugin-proposal-object-rest-spread'),
 			isProd &&
 				require.resolve('babel-plugin-transform-react-remove-prop-types'),

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -15,7 +15,7 @@ const baseConfig = require('./webpack-base-config');
 const BabelEsmPlugin = require('babel-esm-plugin');
 const { InjectManifest } = require('workbox-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
-const RefreshPlugin = require('preact-refresh');
+const RefreshPlugin = require('@prefresh/webpack');
 const { normalizePath, warn } = require('../../util');
 
 const cleanFilename = (name) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
   "bugs": "https://github.com/developit/preact-cli/issues",
   "homepage": "https://github.com/developit/preact-cli",
   "devDependencies": {
+    "@prefresh/webpack": "0.6.0",
     "eslint": "^6.1.0",
     "html-looks-like": "^1.0.2",
     "jest": "^25.1.0",
@@ -57,10 +58,10 @@
     "polka": "^0.5.2",
     "preact": "^10.0.0",
     "preact-compat": "^3.18.5",
-    "preact-refresh": "0.3.1",
     "preact-render-to-string": "^5.0.6",
     "preact-router": "^3.0.1",
     "puppeteer": "^2.1.1",
+    "react-refresh": "0.8.2",
     "sass-loader": "^8.0.2",
     "shelljs": "^0.8.3",
     "sirv": "^1.0.0-next.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,6 +1901,24 @@
   version "1.0.0-next.11"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
 
+"@prefresh/core@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.6.0.tgz#b7801ad3d16de9d21ed0824db6c85707f93cf93c"
+  integrity sha512-xhhBgQeMmyoSYEr8F27oypxRTWysIKPnc+Ed6U5OmEwPtLeKsccI3UCpSQyrcv5/HmPNPjAYHPqNC0uH57rIkw==
+
+"@prefresh/utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-0.1.0.tgz#9b69c9ecd6002e72e096e5e72f4bd4f88d15284c"
+  integrity sha512-xtUsQMJIHwBuiXu1E1iiXNVfn60N6zpVUo67ZvQVA6OMlslQzWtbdnTXRT+iplBBgfLmQvXR0bKsNz1+ZYSMgw==
+
+"@prefresh/webpack@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-0.6.0.tgz#fec281c8b94e5455646686eb4c123a7b22004dd3"
+  integrity sha512-z9S1jknJZsc9xmMsX/3nNae8CxKavlOH0YydDjdld41WYB4A2UkC7+rl4P+XH7www9HpGcXzmqgDfFKGGJnNEg==
+  dependencies:
+    "@prefresh/core" "0.6.0"
+    "@prefresh/utils" "0.1.0"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz#8c6e59c4b28baf9d223028d0e450e06a485bb2b7"
@@ -9825,11 +9843,6 @@ preact-context@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/preact-context/-/preact-context-1.1.4.tgz#866ebd35bef5788f73fc453f06f01b03ddf8f4ff"
 
-preact-refresh@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/preact-refresh/-/preact-refresh-0.3.1.tgz#0bc5ce157c70bf04010359d0549d9ee9c061f63b"
-  integrity sha512-JxRMIkTCMIx11MDIZQPuUpHlP0r6FHfHAHwx+3m97mbny91IWvmNfUWWfcblyoysWiJ3J5eD952tgljkTmblNQ==
-
 preact-render-to-string@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz#bd72964d705a57da3a9e72098acaa073dd3ceff9"
@@ -10179,6 +10192,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-refresh@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.2.tgz#24bb0858eac92b0d7b0dd561747f0c9fd6c60327"
+  integrity sha512-n8GXxo3DwM2KtFEL69DAVhGc4A1THn2qjmfvSo3nze0NLCoPbywazeJPqdp0RdSGLmyhQzeyA+XPXOobbYlkzg==
 
 read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Converts `preact-refresh` to use the new and improved `@prefresh/webpack`, this will also work for hooks and custom hooks since it uses `react-refresh/babel` to produce function signatures.