### PR TITLE
exclude react-refresh/babel for node_modules

### DIFF
--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -1,4 +1,4 @@
-module.exports = function (env, options = {}) {
+module.exports = function (env, options = {}, isNodeModules) {
 	const { production: isProd, rhl: isRHLEnabled, refresh } = env || {};
 
 	return {
@@ -22,7 +22,10 @@ module.exports = function (env, options = {}) {
 			],
 		],
 		plugins: [
-			!isProd && refresh && require.resolve('react-refresh/babel'),
+			!isProd &&
+				!isNodeModules &&
+				refresh &&
+				require.resolve('react-refresh/babel'),
 			require.resolve('@babel/plugin-syntax-dynamic-import'),
 			require.resolve('@babel/plugin-transform-object-assign'),
 			[require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],

--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -32,26 +32,19 @@ module.exports = function (env, options = {}) {
 		overrides: [
 			// Transforms to apply only to first-party code:
 			{
-				exclude: /(^|\/|\\)node_modules(\/|\\/)/,
+				exclude: /(^|\/|\\)node_modules(\/|\/)/,
 				presets: [
-					[
-						require.resolve('@babel/preset-typescript'),
-						{ jsxPragma: 'h' },
-					]
+					[require.resolve('@babel/preset-typescript'), { jsxPragma: 'h' }],
 				],
 				plugins: [
 					[
 						require.resolve('@babel/plugin-transform-react-jsx'),
 						{ pragma: 'h', pragmaFrag: 'Fragment' },
 					],
-					!isProd &&
-						refresh &&
-						require.resolve('react-refresh/babel'),
-					!isProd &&
-						isRHLEnabled &&
-						require.resolve('react-hot-loader/babel'),
-				].filter(Boolean)
-			}
-		]
+					!isProd && refresh && require.resolve('react-refresh/babel'),
+					!isProd && isRHLEnabled && require.resolve('react-hot-loader/babel'),
+				].filter(Boolean),
+			},
+		],
 	};
 };

--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -28,6 +28,10 @@ module.exports = function (env, options = {}) {
 				require.resolve('babel-plugin-transform-react-remove-prop-types'),
 			[require.resolve('fast-async'), { spec: true }],
 			require.resolve('babel-plugin-macros'),
+			[
+				require.resolve('@babel/plugin-transform-react-jsx'),
+				{ pragma: 'h', pragmaFrag: 'Fragment' },
+			],
 		].filter(Boolean),
 		overrides: [
 			// Transforms to apply only to first-party code:
@@ -37,10 +41,6 @@ module.exports = function (env, options = {}) {
 					[require.resolve('@babel/preset-typescript'), { jsxPragma: 'h' }],
 				],
 				plugins: [
-					[
-						require.resolve('@babel/plugin-transform-react-jsx'),
-						{ pragma: 'h', pragmaFrag: 'Fragment' },
-					],
 					!isProd && refresh && require.resolve('react-refresh/babel'),
 					!isProd && isRHLEnabled && require.resolve('react-hot-loader/babel'),
 				].filter(Boolean),

--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -1,14 +1,8 @@
-module.exports = function (env, options = {}, isNodeModules) {
+module.exports = function (env, options = {}) {
 	const { production: isProd, rhl: isRHLEnabled, refresh } = env || {};
 
 	return {
 		presets: [
-			[
-				require.resolve('@babel/preset-typescript'),
-				{
-					jsxPragma: 'h',
-				},
-			],
 			[
 				require.resolve('@babel/preset-env'),
 				{
@@ -22,10 +16,6 @@ module.exports = function (env, options = {}, isNodeModules) {
 			],
 		],
 		plugins: [
-			!isProd &&
-				!isNodeModules &&
-				refresh &&
-				require.resolve('react-refresh/babel'),
 			require.resolve('@babel/plugin-syntax-dynamic-import'),
 			require.resolve('@babel/plugin-transform-object-assign'),
 			[require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
@@ -36,13 +26,32 @@ module.exports = function (env, options = {}, isNodeModules) {
 			require.resolve('@babel/plugin-proposal-object-rest-spread'),
 			isProd &&
 				require.resolve('babel-plugin-transform-react-remove-prop-types'),
-			[
-				require.resolve('@babel/plugin-transform-react-jsx'),
-				{ pragma: 'h', pragmaFrag: 'Fragment' },
-			],
 			[require.resolve('fast-async'), { spec: true }],
 			require.resolve('babel-plugin-macros'),
-			!isProd && isRHLEnabled && require.resolve('react-hot-loader/babel'),
 		].filter(Boolean),
+		overrides: [
+			// Transforms to apply only to first-party code:
+			{
+				exclude: /(^|\/|\\)node_modules(\/|\\/)/,
+				presets: [
+					[
+						require.resolve('@babel/preset-typescript'),
+						{ jsxPragma: 'h' },
+					]
+				],
+				plugins: [
+					[
+						require.resolve('@babel/plugin-transform-react-jsx'),
+						{ pragma: 'h', pragmaFrag: 'Fragment' },
+					],
+					!isProd &&
+						refresh &&
+						require.resolve('react-refresh/babel'),
+					!isProd &&
+						isRHLEnabled &&
+						require.resolve('react-hot-loader/babel'),
+				].filter(Boolean)
+			}
+		]
 	};
 };

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -73,6 +73,7 @@ async function devBuild(env) {
 
 		let c = Object.assign({}, config.devServer, {
 			stats: { colors: true },
+			hot: !env.refresh,
 		});
 
 		let server = new DevServer(compiler, c);

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -164,24 +164,9 @@ module.exports = function (env) {
 					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
 					type: 'javascript/auto',
 					loader: 'babel-loader',
-					include: /node_modules/,
 					options: Object.assign(
 						{ babelrc: false },
-						createBabelConfig(env, { browsers }, true),
-						babelrc // intentionally overwrite our settings
-					),
-				},
-				{
-					// ES2015
-					enforce: 'pre',
-					test: /\.m?[jt]sx?$/,
-					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
-					type: 'javascript/auto',
-					loader: 'babel-loader',
-					exclude: /node_modules/,
-					options: Object.assign(
-						{ babelrc: false },
-						createBabelConfig(env, { browsers }, false),
+						createBabelConfig(env, { browsers }),
 						babelrc // intentionally overwrite our settings
 					),
 				},

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -71,7 +71,7 @@ function getSassConfiguration(...includePaths) {
 	return config;
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
 	const { cwd, isProd, isWatch, src, source } = env;
 	const babelConfigFile = env.babelConfig || '.babelrc';
 	const IS_SOURCE_PREACT_X_OR_ABOVE = isInstalledVersionPreactXOrAbove(cwd);
@@ -100,12 +100,6 @@ module.exports = function(env) {
 		requireRelative.resolve('preact/compat', cwd);
 		compat = 'preact/compat';
 	} catch (e) {}
-
-	let babelConfig = Object.assign(
-		{ babelrc: false },
-		createBabelConfig(env, { browsers }),
-		babelrc // intentionally overwrite our settings
-	);
 
 	let tsconfig = resolveTsconfig(cwd, isProd);
 
@@ -170,7 +164,26 @@ module.exports = function(env) {
 					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
 					type: 'javascript/auto',
 					loader: 'babel-loader',
-					options: babelConfig,
+					include: /node_modules/,
+					options: Object.assign(
+						{ babelrc: false },
+						createBabelConfig(env, { browsers }, true),
+						babelrc // intentionally overwrite our settings
+					),
+				},
+				{
+					// ES2015
+					enforce: 'pre',
+					test: /\.m?[jt]sx?$/,
+					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
+					type: 'javascript/auto',
+					loader: 'babel-loader',
+					exclude: /node_modules/,
+					options: Object.assign(
+						{ babelrc: false },
+						createBabelConfig(env, { browsers }, false),
+						babelrc // intentionally overwrite our settings
+					),
 				},
 				{
 					// LESS
@@ -332,7 +345,7 @@ module.exports = function(env) {
 							patterns: [
 								{
 									regex: /throw\s+(new\s+)?(Type|Reference)?Error\s*\(/g,
-									value: s => `return;${Array(s.length - 7).join(' ')}(`,
+									value: (s) => `return;${Array(s.length - 7).join(' ')}(`,
 								},
 							],
 						}),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes a bug where prefresh would get confused because of node_modules (the loader isn't injected for it for perf reasons). This was added in 0.6 and makes prefresh work again, still trying to figure out the call-stack bug.

**Did you add tests for your changes?**

No
