### PR TITLE
Fix: apple-touch-icon when a router is used

### DIFF
--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width,initial-scale=1">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-capable" content="yes">
-		<link rel="apple-touch-icon" href="./assets/icons/apple-touch-icon.png">
+		<link rel="apple-touch-icon" href="/assets/icons/apple-touch-icon.png">
 		<% preact.headEnd %>
 	</head>
 	<body>

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -64,7 +64,7 @@ exports.prerender.heads.home = `
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
-	<link rel="apple-touch-icon" href=\\"\\.\\/assets\\/icons\\/apple-touch-icon\\.png\\">
+	<link rel="apple-touch-icon" href=\\"\\/assets\\/icons\\/apple-touch-icon\\.png\\">
 	<link rel="manifest" href="\\/manifest\\.json">
 	<style>html{padding:0}<\\/style>
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\" onload=\\"this.rel='stylesheet'\\">
@@ -81,7 +81,7 @@ exports.prerender.heads.route66 = `
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
-	<link rel="apple-touch-icon" href=\\"\\.\\/assets\\/icons\\/apple-touch-icon\\.png\\">
+	<link rel="apple-touch-icon" href=\\"\\/assets\\/icons\\/apple-touch-icon\\.png\\">
 	<link rel="manifest" href="\\/manifest\\.json">
 	<style>html{padding:0}<\\/style>
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\" onload=\\"this.rel='stylesheet'\\">
@@ -98,7 +98,7 @@ exports.prerender.heads.custom = `
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
-	<link rel="apple-touch-icon" href=\\"\\.\\/assets\\/icons\\/apple-touch-icon\\.png\\">
+	<link rel="apple-touch-icon" href=\\"\\/assets\\/icons\\/apple-touch-icon\\.png\\">
 	<link rel="manifest" href="\\/manifest\\.json">
 	<style>html{padding:0}<\\/style>
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\" onload=\\"this.rel='stylesheet'\\">
@@ -117,7 +117,7 @@ exports.preload.head = `
 	<meta name=\\"viewport\\" content=\\"width=device-width,initial-scale=1\\">
 	<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">
 	<meta name=\\"apple-mobile-web-app-capable\\" content=\\"yes\\">
-	<link rel=\\"apple-touch-icon\\" href=\\"\\.\\/assets\\/icons\\/apple-touch-icon\\.png\\">
+	<link rel=\\"apple-touch-icon\\" href=\\"\\/assets\\/icons\\/apple-touch-icon\\.png\\">
 	<link rel=\\"manifest\\" href=\\"\\/manifest\\.json\\">
 	<link rel=\\"preload\\" href=\\"\\/bundle\\.\\w{5}\\.js\\" as=\\"script\\">
 	<link rel=\\"preload\\" href=\\"\\/route-home\\.chunk\\.\\w{5}\\.js\\" as=\\"script\\">


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bug fix in regards to the apple-touch-icon. 

**Did you add tests for your changes?**

No, but I did edit the existing tests. Simply removed the `.` in the resource URI for the test like I did in the template.

**Summary**

I noticed while developing an application that if the route for a component were `/x/y/z`, the template would try to import the apple-touch-icon from `/x/y/assets/icons/apple-touch-icon.png`, which would always result in a 404. This PR fixes that issue by not making the import relative to the current directory.

I believe this should not cause any issues, but I've only tested with and without `preact-router` in particular. 

**Does this PR introduce a breaking change?**

No.