### PR TITLE
Use `lessOptions`

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -182,7 +182,9 @@ module.exports = function (env) {
 								loader: 'less-loader',
 								options: {
 									sourceMap: true,
-									paths: [nodeModules],
+									lessOptions: {
+										paths: [nodeModules],
+									},
 								},
 							},
 						},


### PR DESCRIPTION
this one didn't require the property hiding from sass-loader (#964) since it's within the existing options object.

Should fix #1173.