### PR TITLE
Bump babel-esm-plugin to v0.9.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,7 +81,7 @@
     "@preact/async-loader": "^3.0.0-rc.9",
     "@prefresh/webpack": "0.7.1",
     "autoprefixer": "^9.6.0",
-    "babel-esm-plugin": "^0.8.0",
+    "babel-esm-plugin": "^0.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-macros": "^2.5.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,9 +2708,10 @@ babel-eslint@^10.0.1:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
-babel-esm-plugin@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/babel-esm-plugin/-/babel-esm-plugin-0.8.1.tgz#57856418bcd24661618d976d13f9f1b9e91a31da"
+babel-esm-plugin@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/babel-esm-plugin/-/babel-esm-plugin-0.9.0.tgz#4d7245965fb914fb8341089825da9c0267cc9ec9"
+  integrity sha512-OyPyLI6LUuUqNm3HNUldAkynWrLzXkhcZo4fGTsieCgHqvbCoCIMMOwJmfG9Lmp91S7WDIuUr0mvOeI8pAb/pw==
   dependencies:
     chalk "2.4.1"
     deepcopy "1.0.0"


### PR DESCRIPTION
Updates babel-esm-plugin to latest version.

Fixes #1206 