### PR TITLE
bugfix: compare prerender URL with normalized pathname

### DIFF
--- a/packages/cli/lib/lib/entry.js
+++ b/packages/cli/lib/lib/entry.js
@@ -55,7 +55,7 @@ if (typeof app === 'function') {
 			process.env.PRERENDER &&
 			process.env.NODE_ENV === 'production' &&
 			hydrate &&
-			currentURL === location.pathname;
+			currentURL === normalizeURL(location.pathname);
 		const doRender = canHydrate ? hydrate : render;
 		root = doRender(h(app, { CLI_DATA }), document.body, root);
 	};


### PR DESCRIPTION
Currently `entry.js` includes logic to check whether the current URL has been prerendered and can be hydrated. The comparison is between a normalized url (appended with a `\`) and the current `location.pathname`.

That means that in a situation where `/user/` has been prerendered and the client requests `/user` it will not hydrate but instead render the entire page.

Normalizing the `location.pathname` just like the prerender url will solve this.
