### PR TITLE
Fix async-loader for Preact X

### DIFF
--- a/packages/async-loader/async.js
+++ b/packages/async-loader/async.js
@@ -2,8 +2,28 @@ import { h, Component } from 'preact';
 
 const PENDING = {};
 
+// Given a VNode, finds its previous element sibling.
+function getPreviousSibling(vnode) {
+	const parent = vnode.__;
+	if (!parent) return;
+	let children = parent.__k;
+	if (children) {
+		if (!Array.isArray(children)) children = [children];
+		// only search previous children
+		let end = children.indexOf(vnode);
+		if (end === -1) end = children.length;
+		for (let i=end; i--; ) {
+			const child = children[i];
+			const dom = child && child.__e || getPreviousSibling(child);
+			if (dom) return dom;
+		}
+	}
+	return getPreviousSibling(parent);
+}
+
 export default function async(load) {
 	let component;
+
 	function AsyncComponent() {
 		Component.call(this);
 
@@ -23,7 +43,8 @@ export default function async(load) {
 				return h(component, props);
 			}
 
-			const me = (this.__P || this._parentDom).lastChild;
+			const prev = getPreviousSibling(this.__v);
+			const me = prev && prev.nextSibling || (this.__P || this._parentDom).firstChild;
 
 			return (
 				me &&

--- a/packages/async-loader/async.js
+++ b/packages/async-loader/async.js
@@ -2,8 +2,10 @@ import { h, Component } from 'preact';
 
 const PENDING = {};
 
-// Given a VNode, finds its previous element sibling.
-function getPreviousSibling(vnode) {
+// Given a VNode, finds its previous element sibling
+function getPreviousSibling(vnode, inner) {
+	// in an element parent with no preceeding siblings means we're the first child
+	if (typeof vnode.type === 'string') return null;
 	const parent = vnode.__;
 	if (!parent) return;
 	let children = parent.__k;
@@ -14,11 +16,11 @@ function getPreviousSibling(vnode) {
 		if (end === -1) end = children.length;
 		for (let i=end; i--; ) {
 			const child = children[i];
-			const dom = child && child.__e || getPreviousSibling(child);
+			const dom = child && child.__e || getPreviousSibling(child, true);
 			if (dom) return dom;
 		}
 	}
-	return getPreviousSibling(parent);
+	if (!inner) return getPreviousSibling(parent);
 }
 
 export default function async(load) {


### PR DESCRIPTION
I finally (FINALLY) found a solid working solution for async hydration (#1293, #1308, etc etc).

Unlike our various earlier attempts, this solution doesn't rely on DOM hacks, pointers or guessing. It crawls up the tree of VNodes, performing a Depth First Search of their children, working backwards from the position of AsyncComponent in order to find the most recently hydrated DOM element. Essentially, the first populated `vnode._dom` reference it finds is guaranteed to be the previous sibling of the parent element AsyncComponent is about to get rendered into. As long as AsyncComponent isn't being used load a component that renders a Fragment, the nextSibling of that discovered element is the exact node Preact will try to hydrate.

You can think of this algorithm as "find the last attached DOM node _before_ me in the virtual DOM tree within my nearest element parent".

In the case of an AsyncComponent wrapping a Fragment, only the first Fragment child will be hydrated. This means the remaining children will have the flicker effect, but that's pretty reasonable:

```js
// app.js
import Foo from 'async!./foo';
export default () => <div><Foo /></div>

// foo.js
export default () => <Fragment>
    <h1>Hello</h1>
    <p>world!</p>  // will be culled+reinserted during hydration
</Fragment>
```