### PR TITLE
GH-591 fix sw being loaded from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ $ preact build
     --dest             Specify output directory  (default build)
     --cwd              A directory to use instead of $PWD  (default .)
     --sw               Generate and attach a Service Worker  (default true)
+		--swPath           Specify service worker file location (default is '/)
     --json             Generate build stats for bundle analysis
     --template         Path to custom HTML template
     --preload          Adds preload tags to the document its assets  (default false)
@@ -143,6 +144,7 @@ $ preact watch
     --cwd           A directory to use instead of $PWD  (default .)
     --esm           Builds ES-2015 bundles for your code.  (default true)
     --sw            Generate and attach a Service Worker  (default false)
+		--swPath           Specify service worker file location (default is '/)
     --json          Generate build stats for bundle analysis
     --https         Run server with HTTPS protocol
     --key           Path to PEM key for custom SSL certificate

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -86,6 +86,7 @@ prog
 	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
+	.option('--swPath', 'Specify service worker file location, default is root', '/')
 	.option('--babelConfig', 'Specify the babel config file', '.babelrc')
 	.option('--rhl', '(Deprecated) use --refresh instead', false)
 	.option('--json', 'Generate build stats for bundle analysis')

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -37,6 +37,7 @@ prog
 	.option('--dest', 'Specify output directory', 'build')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
 	.option('--sw', 'Generate and attach a Service Worker', true)
+	.option('--swPath', 'Specify service worker file location, default is root', '/')
 	.option('--json', 'Generate build stats for bundle analysis')
 	.option('--template', 'Path to custom HTML template')
 	.option('--preload', 'Adds preload tags to the document its assets', false)

--- a/packages/cli/lib/lib/entry.js
+++ b/packages/cli/lib/lib/entry.js
@@ -1,5 +1,3 @@
-/* global __webpack_public_path__ */
-
 import * as Preact from 'preact';
 const { h, render, hydrate } = Preact;
 
@@ -14,17 +12,17 @@ if (process.env.NODE_ENV === 'development') {
 	// only add a debug sw if webpack service worker is not requested.
 	if (process.env.ADD_SW === undefined && 'serviceWorker' in navigator) {
 		// eslint-disable-next-line no-undef
-		navigator.serviceWorker.register(__webpack_public_path__ + 'sw-debug.js');
+		navigator.serviceWorker.register(process.env.SW_PATH + 'sw-debug.js');
 	} else if (process.env.ADD_SW && 'serviceWorker' in navigator) {
 		// eslint-disable-next-line no-undef
 		navigator.serviceWorker.register(
-			__webpack_public_path__ + (process.env.ES_BUILD ? 'sw-esm.js' : 'sw.js')
+			process.env.SW_PATH + (process.env.ES_BUILD ? 'sw-esm.js' : 'sw.js')
 		);
 	}
 } else if (process.env.ADD_SW && 'serviceWorker' in navigator) {
 	// eslint-disable-next-line no-undef
 	navigator.serviceWorker.register(
-		__webpack_public_path__ + (process.env.ES_BUILD ? 'sw-esm.js' : 'sw.js')
+		process.env.SW_PATH + (process.env.ES_BUILD ? 'sw-esm.js' : 'sw.js')
 	);
 }
 

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -204,6 +204,7 @@ function isProd(config) {
 				'process.env.ES_BUILD': false,
 				'process.env.ESM': config.esm,
 				'process.env.PRERENDER': config.prerender,
+				'process.env.SW_PATH': JSON.stringify(config.swPath),
 			}),
 		],
 
@@ -314,6 +315,7 @@ function isDev(config) {
 			new webpack.DefinePlugin({
 				'process.env.ADD_SW': config.sw,
 				'process.env.PRERENDER': config.prerender,
+				'process.env.SW_PATH': JSON.stringify(config.swPath),
 			}),
 		],
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug Fix, this will close #591
- refactored entry.js to use `process.env.SW_PATH` instead of webpack public path
- introduced new cli option for setting swPath, default would be `/`

**Did you add tests for your changes?**
N/A, did a local test though

**Summary**
Service Worker loaded from CDN, see #591 for more details

**Does this PR introduce a breaking change?**

don't think so
