### PR TITLE
Docs(ReadMe): Adding note for installing CLI as root 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@
 $ npm install -g preact-cli
 ```
 
+> **Note**:  
+> If you are installing as root, you will need to add the `unsafe-perm` flag to your install command:
+>
+> ```sh
+> $ sudo npm install -g --unsafe-perm preact-cli
+> ```
+>
+
 ### Usage
 
 ```sh


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adding documentation to cover (what might become) a common issue.

**Did you add tests for your changes?**

N/A

**Summary**

Now that the default install for the CLI is v3.0.0, more people will probably run into the same problem that is presented in #802 and #1342. While running NPM as root, the `unsafe-perm` flag will be set to `false` by default which causes an issue with (at least) `nodent-runtime`. [NPM docs](https://docs.npmjs.com/misc/config#unsafe-perm), [nodent-runtime](https://github.com/MatAtBread/nodent-runtime/issues/5). The simple fix is to add the `unsafe-perm` flag.

As running global installations as root is a pretty common thing to do, having documentation to catch the people who run into this issue is likely worthwhile. 

**Does this PR introduce a breaking change?**

No breaking changes