### PR TITLE
Refactoring documenation for commands/flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,17 @@ $ preact build
     --src              Specify source directory  (default src)
     --dest             Specify output directory  (default build)
     --cwd              A directory to use instead of $PWD  (default .)
+    --esm              Builds ES-2015 bundles for your code.  (default true)
     --sw               Generate and attach a Service Worker  (default true)
+    --babelConfig      Path to custom Babel config (default .babelrc)
     --json             Generate build stats for bundle analysis
     --template         Path to custom HTML template
     --preload          Adds preload tags to the document its assets  (default false)
     --analyze          Launch interactive Analyzer to inspect production bundle(s)
     --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
-    -c, --config       Path to custom CLI config  (default preact.config.js)
-    --babelConfig      Path to custom Babel config (default .babelrc)
-    --esm              Builds ES-2015 bundles for your code.  (default true)
     --brotli           Adds brotli redirects to the service worker.  (default false)
     --inline-css       Adds critical css to the prerendered markup.  (default true)
+    -c, --config       Path to custom CLI config  (default preact.config.js)
     -v, --verbose      Verbose output
     -h, --help         Displays this message
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ $ preact build
     --analyze          Launch interactive Analyzer to inspect production bundle(s)
     --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
     -c, --config       Path to custom CLI config  (default preact.config.js)
+    --babelConfig      Path to custom Babel config (default .babelrc)
     --esm              Builds ES-2015 bundles for your code.  (default true)
     --brotli           Adds brotli redirects to the service worker.  (default false)
     --inline-css       Adds critical css to the prerendered markup.  (default true)
@@ -143,6 +144,7 @@ $ preact watch
     --cwd           A directory to use instead of $PWD  (default .)
     --esm           Builds ES-2015 bundles for your code.  (default true)
     --sw            Generate and attach a Service Worker  (default false)
+    --babelConfig   Path to custom Babel config (default .babelrc)
     --json          Generate build stats for bundle analysis
     --https         Run server with HTTPS protocol
     --key           Path to PEM key for custom SSL certificate

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ preact build
     --src              Specify source directory  (default src)
     --dest             Specify output directory  (default build)
     --cwd              A directory to use instead of $PWD  (default .)
-    --esm              Builds ES-2015 bundles for your code.  (default true)
+    --esm              Builds ES-2015 bundles for your code  (default true)
     --sw               Generate and attach a Service Worker  (default true)
     --babelConfig      Path to custom Babel config (default .babelrc)
     --json             Generate build stats for bundle analysis
@@ -126,8 +126,8 @@ $ preact build
     --preload          Adds preload tags to the document its assets  (default false)
     --analyze          Launch interactive Analyzer to inspect production bundle(s)
     --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
-    --brotli           Adds brotli redirects to the service worker.  (default false)
-    --inline-css       Adds critical css to the prerendered markup.  (default true)
+    --brotli           Adds brotli redirects to the service worker  (default false)
+    --inline-css       Adds critical css to the prerendered markup  (default true)
     -c, --config       Path to custom CLI config  (default preact.config.js)
     -v, --verbose      Verbose output
     -h, --help         Displays this message
@@ -142,7 +142,7 @@ $ preact watch
 
     --src              Specify source directory  (default src)
     --cwd              A directory to use instead of $PWD  (default .)
-    --esm              Builds ES-2015 bundles for your code.  (default false)
+    --esm              Builds ES-2015 bundles for your code  (default false)
     --sw               Generate and attach a Service Worker  (default false)
     --babelConfig      Path to custom Babel config (default .babelrc)
     --json             Generate build stats for bundle analysis

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ preact watch
     --src              Specify source directory  (default src)
     --cwd              A directory to use instead of $PWD  (default .)
     --esm              Builds ES-2015 bundles for your code  (default false)
+    --clear            Clear the console (default true)
     --sw               Generate and attach a Service Worker  (default false)
     --babelConfig      Path to custom Babel config (default .babelrc)
     --json             Generate build stats for bundle analysis

--- a/README.md
+++ b/README.md
@@ -140,24 +140,24 @@ Spin up a development server with multiple features like `hot-module-replacement
 ```
 $ preact watch
 
-    --src           Specify source directory  (default src)
-    --cwd           A directory to use instead of $PWD  (default .)
-    --esm           Builds ES-2015 bundles for your code.  (default false)
-    --sw            Generate and attach a Service Worker  (default false)
-    --babelConfig   Path to custom Babel config (default .babelrc)
-    --json          Generate build stats for bundle analysis
-    --https         Run server with HTTPS protocol
-    --key           Path to PEM key for custom SSL certificate
-    --cert          Path to custom SSL certificate
-    --cacert        Path to optional CA certificate override
-    --prerender     Pre-render static content on first run
-    --prerenderUrls Path to pre-rendered routes config  (default prerender-urls.json)
-    --template      Path to custom HTML template
-    --refresh       Will use [`Preact-refresh`](https://github.com/JoviDeCroock/preact-refresh) to do hot-reloading
-    -c, --config    Path to custom CLI config  (default preact.config.js)
-    -H, --host      Set server hostname  (default 0.0.0.0)
-    -p, --port      Set server port  (default 8080)
-    -h, --help      Displays this message
+    --src              Specify source directory  (default src)
+    --cwd              A directory to use instead of $PWD  (default .)
+    --esm              Builds ES-2015 bundles for your code.  (default false)
+    --sw               Generate and attach a Service Worker  (default false)
+    --babelConfig      Path to custom Babel config (default .babelrc)
+    --json             Generate build stats for bundle analysis
+    --https            Run server with HTTPS protocol
+    --key              Path to PEM key for custom SSL certificate
+    --cert             Path to custom SSL certificate
+    --cacert           Path to optional CA certificate override
+    --prerender        Pre-render static content on first run
+    --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
+    --template         Path to custom HTML template
+    --refresh          Will use [`Preact-refresh`](https://github.com/JoviDeCroock/preact-refresh) to do hot-reloading
+    -c, --config       Path to custom CLI config  (default preact.config.js)
+    -H, --host         Set server hostname  (default 0.0.0.0)
+    -p, --port         Set server port  (default 8080)
+    -h, --help         Displays this message
 ```
 
 Note:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ preact watch
 
     --src           Specify source directory  (default src)
     --cwd           A directory to use instead of $PWD  (default .)
-    --esm           Builds ES-2015 bundles for your code.  (default true)
+    --esm           Builds ES-2015 bundles for your code.  (default false)
     --sw            Generate and attach a Service Worker  (default false)
     --babelConfig   Path to custom Babel config (default .babelrc)
     --json          Generate build stats for bundle analysis

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ $ preact watch
     --cert          Path to custom SSL certificate
     --cacert        Path to optional CA certificate override
     --prerender     Pre-render static content on first run
+    --prerenderUrls Path to pre-rendered routes config  (default prerender-urls.json)
     --template      Path to custom HTML template
     --refresh       Will use [`Preact-refresh`](https://github.com/JoviDeCroock/preact-refresh) to do hot-reloading
     -c, --config    Path to custom CLI config  (default preact.config.js)

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -43,11 +43,6 @@ prog
 	.option('--template', 'Path to custom HTML template')
 	.option('--preload', 'Adds preload tags to the document its assets', false)
 	.option(
-		'--refresh',
-		'Enables experimental preact-refresh functionality',
-		false
-	)
-	.option(
 		'--analyze',
 		'Launch interactive Analyzer to inspect production bundle(s)'
 	)
@@ -94,7 +89,11 @@ prog
 	.option('--cacert', 'Path to optional CA certificate override')
 	.option('--prerender', 'Pre-render static content on first run')
 	.option('--template', 'Path to custom HTML template')
-	.option('--refresh', 'Will use Preact-Refresh to do hot-reloading', false)
+	.option(
+		'--refresh',
+		'Enables experimental preact-refresh functionality',
+		false
+	)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-H, --host', 'Set server hostname', '0.0.0.0')
 	.option('-p, --port', 'Set server port', 8080)

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -32,7 +32,9 @@ let prog = sade('preact').version(pkg.version);
 
 prog
 	.command('build [src]')
-	.describe('Create a production build')
+	.describe(
+		'Create a production build. You can disable "default: true" flags by prefixing them with --no-<option>'
+	)
 	.option('--src', 'Specify source directory', 'src')
 	.option('--dest', 'Specify output directory', 'build')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -55,7 +55,7 @@ prog
 		'prerender-urls.json'
 	)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
-	.option('--babelConfig', 'Specify the babel config file', '.babelrc')
+	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
 	.option('--esm', 'Builds ES-2015 bundles for your code.', true)
 	.option('--brotli', 'Builds brotli compressed bundles of javascript.', false)
 	.option('--inline-css', 'Adds critical css to the prerendered markup.', true)
@@ -85,7 +85,7 @@ prog
 	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
-	.option('--babelConfig', 'Specify the babel config file', '.babelrc')
+	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
 	.option('--rhl', '(Deprecated) use --refresh instead', false)
 	.option('--json', 'Generate build stats for bundle analysis')
 	.option('--https', 'Run server with HTTPS protocol')

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -94,6 +94,7 @@ prog
 	.option('--cacert', 'Path to optional CA certificate override')
 	.option('--prerender', 'Pre-render static content on first run')
 	.option('--template', 'Path to custom HTML template')
+	.option('--refresh', 'Will use Preact-Refresh to do hot-reloading', false)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-H, --host', 'Set server hostname', '0.0.0.0')
 	.option('-p, --port', 'Set server port', 8080)

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -88,6 +88,11 @@ prog
 	.option('--cert', 'Path to custom SSL certificate')
 	.option('--cacert', 'Path to optional CA certificate override')
 	.option('--prerender', 'Pre-render static content on first run')
+	.option(
+		'--prerenderUrls',
+		'Path to pre-rendered routes config',
+		'prerender-urls.json'
+	)
 	.option('--template', 'Path to custom HTML template')
 	.option(
 		'--refresh',
@@ -97,11 +102,6 @@ prog
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-H, --host', 'Set server hostname', '0.0.0.0')
 	.option('-p, --port', 'Set server port', 8080)
-	.option(
-		'--prerenderUrls',
-		'Path to pre-rendered routes config',
-		'prerender-urls.json'
-	)
 	.action(commands.watch);
 
 prog

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -36,7 +36,9 @@ prog
 	.option('--src', 'Specify source directory', 'src')
 	.option('--dest', 'Specify output directory', 'build')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
+	.option('--esm', 'Builds ES-2015 bundles for your code.', true)
 	.option('--sw', 'Generate and attach a Service Worker', true)
+	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
 	.option('--json', 'Generate build stats for bundle analysis')
 	.option('--template', 'Path to custom HTML template')
 	.option('--preload', 'Adds preload tags to the document its assets', false)
@@ -54,11 +56,9 @@ prog
 		'Path to pre-rendered routes config',
 		'prerender-urls.json'
 	)
-	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
-	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
-	.option('--esm', 'Builds ES-2015 bundles for your code.', true)
 	.option('--brotli', 'Builds brotli compressed bundles of javascript.', false)
 	.option('--inline-css', 'Adds critical css to the prerendered markup.', true)
+	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-v, --verbose', 'Verbose output')
 	.action(commands.build);
 

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -38,7 +38,7 @@ prog
 	.option('--src', 'Specify source directory', 'src')
 	.option('--dest', 'Specify output directory', 'build')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code.', true)
+	.option('--esm', 'Builds ES-2015 bundles for your code', true)
 	.option('--sw', 'Generate and attach a Service Worker', true)
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
 	.option('--json', 'Generate build stats for bundle analysis')
@@ -53,8 +53,8 @@ prog
 		'Path to pre-rendered routes config',
 		'prerender-urls.json'
 	)
-	.option('--brotli', 'Builds brotli compressed bundles of javascript.', false)
-	.option('--inline-css', 'Adds critical css to the prerendered markup.', true)
+	.option('--brotli', 'Builds brotli compressed bundles of javascript', false)
+	.option('--inline-css', 'Adds critical css to the prerendered markup', true)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-v, --verbose', 'Verbose output')
 	.action(commands.build);
@@ -79,7 +79,7 @@ prog
 	.describe('Start a live-reload server for development')
 	.option('--src', 'Specify source directory', 'src')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
+	.option('--esm', 'Builds ES-2015 bundles for your code', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Mostly simple refactoring

**Did you add tests for your changes?**

N/A

**Summary**

As I went to fix #1360, as it is a valid concern, I noticed the documentation was a bit messy in areas. The flags for `build` vs `watch` were in completely different orders, 1-2 flags had incorrect defaults listed in the README, some valid flags weren't documented at all, and there were grammatical inconsistencies throughout. This PR fixes those issues. 

**Does this PR introduce a breaking change?**

No