### PR TITLE
Copy manifest.json only if it exists

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -98,18 +98,7 @@ async function clientConfig(env) {
 			...getBabelEsmPlugin(env),
 			new CopyWebpackPlugin(
 				[
-					...(existsSync(source('manifest.json'))
-						? [{ from: 'manifest.json' }]
-						: [
-								{
-									from: resolve(__dirname, '../../resources/manifest.json'),
-									to: 'manifest.json',
-								},
-								{
-									from: resolve(__dirname, '../../resources/icon.png'),
-									to: 'assets/icon.png',
-								},
-						  ]),
+					existsSync(source('manifest.json')) && { from: 'manifest.json' },
 					// copy any static files
 					existsSync(source('assets')) && { from: 'assets', to: 'assets' },
 					// copy sw-debug


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

This change makes sure `manifest.json` is copied in `build` only if it exists in `src`. 
This prevents boilerplate manifest and icon to be copied over in the case when user moves `manifest.json` somewhere else (like `assets` or `static`). 
Since almost all templates (sans widget I think) come with predefined manifest that at least populates correct project name, if that manifest is removed I would assume it's on purpose and should not be replaced with boilerplate "preact app" one.

**Does this PR introduce a breaking change?**

No
