### PR TITLE
Removed explicit webpack entries in dev

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -36,14 +36,6 @@ async function clientConfig(env) {
 		polyfills: resolve(__dirname, './polyfills'),
 	};
 
-	if (!isProd) {
-		entry.bundle = [
-			entry.bundle,
-			'webpack-dev-server/client',
-			'webpack/hot/dev-server',
-		];
-	}
-
 	return {
 		entry: entry,
 		output: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bigfix to remove duplicate requires for `webpack-dev-server/client` which end up causing unnecessary traffic and errors.

**Did you add tests for your changes?**

No tests were added

**Summary**

Fixes #1387

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**

According to webpack/webpack-dev-server#711 we don't need to explicitly include these entries as they are added automatically.
