### PR TITLE
remove installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ### Contents
 
 - [Features](#features)
-- [Installation](#installation)
 - [Usage](#usage)
 - [Official Templates](#official-templates)
 - [CLI Options](#cli-options)


### PR DESCRIPTION
Since the usage option explains the installation steps, and the installation option doesn't link anything in the `README`, it seems like it can be removed.
