### PR TITLE
Fix mangled size-plugin output  when SSR is enabled

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -3,7 +3,6 @@ const path = require('path');
 const { resolve } = require('path');
 const { readFileSync, existsSync } = require('fs');
 const { isInstalledVersionPreactXOrAbove } = require('./utils');
-const SizePlugin = require('size-plugin');
 const autoprefixer = require('autoprefixer');
 const browserslist = require('browserslist');
 const requireRelative = require('require-relative');
@@ -309,7 +308,6 @@ module.exports = function (env) {
 				summary: false,
 				clear: true,
 			}),
-			new SizePlugin(),
 			...(tsconfig
 				? [
 						new ForkTsCheckerWebpackPlugin({

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -4,6 +4,7 @@ const { existsSync } = require('fs');
 const { isInstalledVersionPreactXOrAbove } = require('./utils');
 const merge = require('webpack-merge');
 const { filter } = require('minimatch');
+const SizePlugin = require('size-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -183,6 +184,7 @@ function isProd(config) {
 				'process.env.ESM': config.esm,
 				'process.env.PRERENDER': config.prerender,
 			}),
+			new SizePlugin()
 		],
 
 		optimization: {

--- a/packages/cli/lib/lib/webpack/webpack-server-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-server-config.js
@@ -1,4 +1,5 @@
 const { resolve } = require('path');
+const SizePlugin = require('size-plugin');
 const merge = require('webpack-merge');
 const baseConfig = require('./webpack-base-config');
 
@@ -23,6 +24,9 @@ function serverConfig(env) {
 				async: resolve(__dirname, './dummy-loader'),
 			},
 		},
+		plugins: [
+			new SizePlugin({ filename: 'size-plugin-ssr.json' }),
+		]
 	};
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No

**Summary**

Currently, running `npm run build` on a fresh preact-cli project produces a mangled output for `size-plugin`, because it writes both the output of the SSR build and the client build to the same output file.

As a result, the output is completely unusable:

![image](https://user-images.githubusercontent.com/202527/92475739-8dae3d80-f1e6-11ea-9f2b-5ba77e7a82e0.png)

This fix introduces a separate `size-plugin-ssr.json` output for the SSR build. After that, we get proper tracking of the size changes for the SSR and client builds:

![image](https://user-images.githubusercontent.com/202527/92475650-6bb4bb00-f1e6-11ea-803d-57842339416b.png)


**Does this PR introduce a breaking change?**

The addition of a second output file for `size-plugin` should not be a breaking change. 

**Other information**

```
➜  preact-test4 git:(master) ✗ preact info

Environment Info:
  System:
    OS: Linux 4.15 Ubuntu 16.04.7 LTS (Xenial Xerus)
    CPU: (16) x64 Intel(R) Core(TM) i9-9900KS CPU @ 4.00GHz
  Binaries:
    Node: 14.8.0 - ~/.nvm/versions/node/v14.8.0/bin/node
    Yarn: 1.21.1 - /usr/bin/yarn
    npm: 6.14.7 - ~/.nvm/versions/node/v14.8.0/bin/npm
  Browsers:
    Chrome: 85.0.4183.83
    Firefox: 80.0.1
  npmPackages:
    preact: ^10.1.0 => 10.4.8 
    preact-cli: ^3.0.0 => 3.0.1 
    preact-render-to-string: ^5.1.2 => 5.1.10 

```
