### PR TITLE
feat(cli): add monorepo and Yarn PnP support

### DIFF
--- a/.changeset/wicked-baboons-visit.md
+++ b/.changeset/wicked-baboons-visit.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': minor
+---
+
+Added monorepo and Yarn PnP support by correctly loading dependencies, removing faulty install checks, and adding undeclared dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,36 @@ jobs:
           LIGHTHOUSE_CHROMIUM_PATH: 'which google-chrome-stable'
         run: npm run test
 
+  pnpTest:
+    name: PnPTest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Run PnP test
+        run: |
+          git clone https://github.com/preactjs-templates/default.git default
+          cd default/template
+          touch yarn.lock
+          echo $(cat package.json | jq '.name = "pnp-test"') > package.json
+          yarn set version 2
+          yarn config set pnpFallbackMode none
+          yarn config set compressionLevel 0
+          yarn link -A -p ../..
+          yarn build
+
   ci-success:
     name: ci
     if: ${{ success() }}
     needs:
       - test
+      - pnpTest
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -1,7 +1,6 @@
 const rimraf = require('rimraf');
 const { resolve } = require('path');
 const { promisify } = require('util');
-const { isDir, error } = require('../util');
 const runWebpack = require('../lib/webpack/run-webpack');
 const { validateArgs } = require('./validate-args');
 
@@ -94,15 +93,6 @@ async function command(src, argv) {
 	argv.production = toBool(argv.production);
 
 	let cwd = resolve(argv.cwd);
-	let modules = resolve(cwd, 'node_modules');
-
-	if (!isDir(modules)) {
-		return error(
-			'No `node_modules` found! Please run `npm install` before continuing.',
-			1
-		);
-	}
-
 	if (argv.clean === void 0) {
 		let dest = resolve(cwd, argv.dest);
 		await promisify(rimraf)(dest);

--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -4,7 +4,6 @@ const { readFileSync } = require('fs');
 const stackTrace = require('stack-trace');
 const URL = require('url');
 const { SourceMapConsumer } = require('source-map');
-const requireRelative = require('require-relative');
 
 module.exports = function (env, params) {
 	params = params || {};
@@ -27,8 +26,10 @@ module.exports = function (env, params) {
 			return '';
 		}
 		const { cwd } = env;
-		const preact = require(requireRelative.resolve('preact', cwd));
-		const renderToString = require(requireRelative.resolve('preact-render-to-string', cwd));
+		const preact = require(require.resolve('preact', { paths: [cwd] }));
+		const renderToString = require(require.resolve('preact-render-to-string', {
+			paths: [cwd],
+		}));
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
 		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];

--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -4,6 +4,7 @@ const { readFileSync } = require('fs');
 const stackTrace = require('stack-trace');
 const URL = require('url');
 const { SourceMapConsumer } = require('source-map');
+const requireRelative = require('require-relative');
 
 module.exports = function (env, params) {
 	params = params || {};
@@ -26,11 +27,8 @@ module.exports = function (env, params) {
 			return '';
 		}
 		const { cwd } = env;
-
-		const preact = require(require.resolve(`${cwd}/node_modules/preact`));
-		const renderToString = require(require.resolve(
-			`${cwd}/node_modules/preact-render-to-string`
-		));
+		const preact = require(requireRelative.resolve('preact', cwd));
+		const renderToString = require(requireRelative.resolve('preact-render-to-string', cwd));
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
 		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];

--- a/packages/cli/lib/lib/webpack/proxy-loader.js
+++ b/packages/cli/lib/lib/webpack/proxy-loader.js
@@ -1,5 +1,4 @@
 var utils = require('loader-utils');
-var requireRelative = require('require-relative');
 
 function proxyLoader(source, map) {
 	var options = utils.getOptions(this);
@@ -17,7 +16,9 @@ function proxyLoader(source, map) {
 
 	var loader;
 	try {
-		loader = requireRelative(proxyOptions.loader, proxyOptions.cwd);
+		loader = require(require.resolve(proxyOptions.loader, {
+			paths: [proxyOptions.cwd],
+		}));
 	} catch (e) {
 		loader = require(proxyOptions.loader);
 	}

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -63,7 +63,7 @@ module.exports = async function (config) {
 			: resolve(dest, url.substring(1), 'index.html');
 		return Object.assign(values, {
 			filename,
-			template: `!!ejs-loader?esModule=false!${template}`,
+			template: `!!${require.resolve('ejs-loader')}?esModule=false!${template}`,
 			minify: isProd && {
 				collapseWhitespace: true,
 				removeScriptTypeAttributes: true,

--- a/packages/cli/lib/lib/webpack/transform-config.js
+++ b/packages/cli/lib/lib/webpack/transform-config.js
@@ -288,7 +288,10 @@ class WebpackConfigHelpers {
 		} catch (e) {}
 
 		let templatePath = isPath
-			? `!!ejs-loader?esModule=false!${resolve(this._cwd, template)}`
+			? `!!${require.resolve('ejs-loader')}?esModule=false!${resolve(
+					this._cwd,
+					template
+			  )}`
 			: template;
 		let { plugin: htmlWebpackPlugin } = this.getPluginsByName(
 			config,

--- a/packages/cli/lib/lib/webpack/utils.js
+++ b/packages/cli/lib/lib/webpack/utils.js
@@ -1,10 +1,11 @@
-const resolveFrom = require('resolve-from');
-
 function isInstalledVersionPreactXOrAbove(cwd) {
 	try {
 		return (
-			parseInt(require(resolveFrom(cwd, 'preact/package.json')).version, 10) >=
-			10
+			parseInt(
+				require(require.resolve('preact/package.json', { paths: [cwd] }))
+					.version,
+				10
+			) >= 10
 		);
 	} catch (e) {}
 	return false;

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -5,7 +5,6 @@ const { readFileSync, existsSync } = require('fs');
 const { isInstalledVersionPreactXOrAbove } = require('./utils');
 const autoprefixer = require('autoprefixer');
 const browserslist = require('browserslist');
-const requireRelative = require('require-relative');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
@@ -97,12 +96,12 @@ module.exports = function (env) {
 	let compat = 'preact-compat';
 	try {
 		compat = dirname(
-			requireRelative.resolve('preact/compat/package.json', cwd)
+			require.resolve('preact/compat/package.json', { paths: [cwd] })
 		);
 	} catch (e) {
 		try {
 			compat = dirname(
-				requireRelative.resolve('preact-compat/package.json', cwd)
+				require.resolve('preact-compat/package.json', { paths: [cwd] })
 			);
 		} catch (e) {}
 	}

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -1,6 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
-const { resolve } = require('path');
+const { resolve, dirname } = require('path');
 const { readFileSync, existsSync } = require('fs');
 const { isInstalledVersionPreactXOrAbove } = require('./utils');
 const autoprefixer = require('autoprefixer');
@@ -96,9 +96,16 @@ module.exports = function (env) {
 
 	let compat = 'preact-compat';
 	try {
-		requireRelative.resolve('preact/compat', cwd);
-		compat = 'preact/compat';
-	} catch (e) {}
+		compat = dirname(
+			requireRelative.resolve('preact/compat/package.json', cwd)
+		);
+	} catch (e) {
+		try {
+			compat = dirname(
+				requireRelative.resolve('preact-compat/package.json', cwd)
+			);
+		} catch (e) {}
+	}
 
 	let tsconfig = resolveTsconfig(cwd, isProd);
 
@@ -138,21 +145,19 @@ module.exports = function (env) {
 				'.css',
 				'.wasm',
 			],
-			alias: Object.assign(
-				{
-					style: source('style'),
-					'preact-cli-entrypoint': source('index'),
-					url: 'native-url',
-					// preact-compat aliases for supporting React dependencies:
-					react: compat,
-					'react-dom': compat,
-					'react-addons-css-transition-group': 'preact-css-transition-group',
-					'preact-cli/async-component': IS_SOURCE_PREACT_X_OR_ABOVE
-						? require.resolve('@preact/async-loader/async')
-						: require.resolve('@preact/async-loader/async-legacy'),
-				},
-				compat !== 'preact-compat' ? { 'preact-compat': compat } : {}
-			),
+			alias: {
+				style: source('style'),
+				'preact-cli-entrypoint': source('index'),
+				url: dirname(require.resolve('native-url/package.json')),
+				// preact-compat aliases for supporting React dependencies:
+				react: compat,
+				'react-dom': compat,
+				'preact-compat': compat,
+				'react-addons-css-transition-group': 'preact-css-transition-group',
+				'preact-cli/async-component': IS_SOURCE_PREACT_X_OR_ABOVE
+					? require.resolve('@preact/async-loader/async')
+					: require.resolve('@preact/async-loader/async-legacy'),
+			},
 		},
 
 		resolveLoader: {

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -12,6 +12,7 @@ const ReplacePlugin = require('webpack-plugin-replace');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const createBabelConfig = require('../babel-config');
 const loadPostcssConfig = require('postcss-load-config');
+const PnpWebpackPlugin = require(`pnp-webpack-plugin`);
 
 function readJson(file) {
 	try {
@@ -157,6 +158,10 @@ module.exports = function (env) {
 					? require.resolve('@preact/async-loader/async')
 					: require.resolve('@preact/async-loader/async-legacy'),
 			},
+			plugins: [
+				// TODO: Remove when upgrading to webpack 5
+				PnpWebpackPlugin,
+			],
 		},
 
 		resolveLoader: {

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -110,6 +110,14 @@ module.exports = function (env) {
 		postcssPlugins = [autoprefixer({ overrideBrowserslist: browsers })];
 	}
 
+	function tryResolveOptionalLoader(name) {
+		try {
+			return require.resolve(name);
+		} catch (e) {
+			return name;
+		}
+	}
+
 	return {
 		context: src,
 
@@ -162,7 +170,7 @@ module.exports = function (env) {
 					test: /\.m?[jt]sx?$/,
 					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
 					type: 'javascript/auto',
-					loader: 'babel-loader',
+					loader: require.resolve('babel-loader'),
 					options: Object.assign(
 						{ babelrc: false },
 						createBabelConfig(env, { browsers }),
@@ -175,10 +183,10 @@ module.exports = function (env) {
 					test: /\.less$/,
 					use: [
 						{
-							loader: 'proxy-loader',
+							loader: require.resolve('./proxy-loader'),
 							options: {
 								cwd,
-								loader: 'less-loader',
+								loader: tryResolveOptionalLoader('less-loader'),
 								options: {
 									sourceMap: true,
 									lessOptions: {
@@ -195,10 +203,10 @@ module.exports = function (env) {
 					test: /\.s[ac]ss$/,
 					use: [
 						{
-							loader: 'proxy-loader',
+							loader: require.resolve('./proxy-loader'),
 							options: {
 								cwd,
-								loader: 'sass-loader',
+								loader: tryResolveOptionalLoader('sass-loader'),
 								options: getSassConfiguration(...nodeModules),
 							},
 						},
@@ -210,10 +218,10 @@ module.exports = function (env) {
 					test: /\.styl$/,
 					use: [
 						{
-							loader: 'proxy-loader',
+							loader: require.resolve('./proxy-loader'),
 							options: {
 								cwd,
-								loader: 'stylus-loader',
+								loader: tryResolveOptionalLoader('stylus-loader'),
 								options: {
 									sourceMap: true,
 									paths: nodeModules,
@@ -227,9 +235,11 @@ module.exports = function (env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					include: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						isWatch
+							? require.resolve('style-loader')
+							: MiniCssExtractPlugin.loader,
 						{
-							loader: 'css-loader',
+							loader: require.resolve('css-loader'),
 							options: {
 								modules: {
 									localIdentName: '[local]__[hash:base64:5]',
@@ -239,7 +249,7 @@ module.exports = function (env) {
 							},
 						},
 						{
-							loader: 'postcss-loader',
+							loader: require.resolve('postcss-loader'),
 							options: {
 								ident: 'postcss',
 								sourceMap: true,
@@ -253,15 +263,17 @@ module.exports = function (env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					exclude: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						isWatch
+							? require.resolve('style-loader')
+							: MiniCssExtractPlugin.loader,
 						{
-							loader: 'css-loader',
+							loader: require.resolve('css-loader'),
 							options: {
 								sourceMap: true,
 							},
 						},
 						{
-							loader: 'postcss-loader',
+							loader: require.resolve('postcss-loader'),
 							options: {
 								ident: 'postcss',
 								sourceMap: true,
@@ -277,11 +289,13 @@ module.exports = function (env) {
 				},
 				{
 					test: /\.(xml|html|txt|md)$/,
-					loader: 'raw-loader',
+					loader: require.resolve('raw-loader'),
 				},
 				{
 					test: /\.(svg|woff2?|ttf|eot|jpe?g|png|webp|gif|mp4|mov|ogg|webm)(\?.*)?$/i,
-					loader: isProd ? 'file-loader' : 'url-loader',
+					loader: isProd
+						? require.resolve('file-loader')
+						: require.resolve('url-loader'),
 				},
 			],
 		},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -130,8 +130,6 @@
 		"prompts": "^2.2.1",
 		"raw-loader": "^4.0.0",
 		"react-refresh": "0.8.3",
-		"require-relative": "^0.8.7",
-		"resolve-from": "^5.0.0",
 		"rimraf": "^3.0.2",
 		"sade": "^1.4.1",
 		"size-plugin": "^2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -123,6 +123,7 @@
 		"native-url": "0.3.4",
 		"optimize-css-assets-webpack-plugin": "^5.0.1",
 		"ora": "^4.0.3",
+		"pnp-webpack-plugin": "^1.6.4",
 		"postcss-load-config": "^2.1.0",
 		"postcss-loader": "^3.0.0",
 		"progress-bar-webpack-plugin": "^2.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
 	"devDependencies": {
 		"html-looks-like": "^1.0.2",
 		"jest": "^26.0.1",
+		"less-loader": "^7.0.1",
 		"ncp": "^2.0.0",
 		"node-sass": "^4.12.0",
 		"p-retry": "^4.1.0",
@@ -57,11 +58,26 @@
 		"puppeteer": "^5.3.1",
 		"sass-loader": "^10.0.4",
 		"shelljs": "^0.8.3",
-		"sirv": "^1.0.0-next.2"
+		"sirv": "^1.0.0-next.2",
+		"stylus-loader": "^3.0.2"
 	},
 	"peerDependencies": {
+		"less-loader": "^7.0.1",
 		"preact": "*",
-		"preact-render-to-string": "*"
+		"preact-render-to-string": "*",
+		"sass-loader": "^10.0.0 || ^9.0.2",
+		"stylus-loader": "^3.0.2"
+	},
+	"peerDependenciesMeta": {
+		"less-loader": {
+			"optional": true
+		},
+		"sass-loader": {
+			"optional": true
+		},
+		"stylus-loader": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"@babel/core": "^7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12366,11 +12366,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-require-relative@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
-  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11187,6 +11187,13 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+pnp-webpack-plugin@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
+  integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  dependencies:
+    ts-pnp "^1.1.6"
+
 polka@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/polka/-/polka-0.5.2.tgz#588bee0c5806dbc6c64958de3a1251860e9f2e26"
@@ -14046,6 +14053,11 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-pnp@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
+  integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tslib@^1.9.0:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8827,6 +8827,15 @@ lerna@^3.16.4:
     import-local "^2.0.0"
     npmlog "^4.1.2"
 
+less-loader@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-7.1.0.tgz#958d41e86d7de0bcb490711ee0f235aa9dc596aa"
+  integrity sha512-EHbnRaTzHgsxnd3RK6OXSiygcCJs72+2ezXVLg+Hgl/ijUTtthKZXZh4MvQkWJr3h/SSKvxGZr7IIHzuS2KbVQ==
+  dependencies:
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -9096,7 +9105,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -13586,6 +13595,15 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylus-loader@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-3.0.2.tgz#27a706420b05a38e038e7cacb153578d450513c6"
+  integrity sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==
+  dependencies:
+    loader-utils "^1.0.2"
+    lodash.clonedeep "^4.5.0"
+    when "~3.6.x"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -14769,6 +14787,11 @@ whatwg-url@^8.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
+
+when@~3.6.x:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.6.4.tgz#473b517ec159e2b85005497a13983f095412e34e"
+  integrity sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix, feature

**Did you add tests for your changes?**

Added an e2e test that will test `preact-cli` for undeclared dependencies and incorrect assumptions about the `node_modules` layout using Yarn PnP's strict dependency checks.

**Summary**

`preact-cli` doesn't work with Yarn PnP and monorepos using `node_modules` due to its incorrect assumptions about the `node_modules` layout, various undeclared dependencies, and not resolving dependencies it provides.

Fixes https://github.com/preactjs/preact-cli/issues/1046
Fixes https://github.com/preactjs/preact-cli/issues/1105
Fixes https://github.com/preactjs/preact-cli/issues/1043

**Does this PR introduce a breaking change?**
No

**Other information**

N/A