### PR TITLE
Better prerender crash message when error originates in node_modules/

### DIFF
--- a/.changeset/twenty-cycles-tickle.md
+++ b/.changeset/twenty-cycles-tickle.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Improves prerender error message when offending use of browser globals cannot be found

--- a/packages/cli/lib/lib/webpack/prerender.js
+++ b/packages/cli/lib/lib/webpack/prerender.js
@@ -32,9 +32,7 @@ module.exports = function (env, params) {
 		}));
 		return renderToString(preact.h(app, { ...params, url }));
 	} catch (err) {
-		let stack = stackTrace
-			.parse(err)
-			.filter((s) => s.getFileName() === entry)[0];
+		let stack = stackTrace.parse(err).filter(s => s.getFileName() === entry)[0];
 		if (!stack) {
 			throw err;
 		}
@@ -50,13 +48,13 @@ async function handlePrerenderError(err, env, stack, entry) {
 	let sourceMapContent, position, sourcePath, sourceLines, sourceCodeHighlight;
 
 	try {
-		sourceMapContent = JSON.parse(readFileSync(`${entry}.map`));
+		sourceMapContent = JSON.parse(readFileSync(`${entry}.map`, 'utf-8'));
 	} catch (err) {
 		process.stderr.write(red(`Unable to read sourcemap: ${entry}.map\n`));
 	}
 
 	if (sourceMapContent) {
-		await SourceMapConsumer.with(sourceMapContent, null, (consumer) => {
+		await SourceMapConsumer.with(sourceMapContent, null, consumer => {
 			position = consumer.originalPositionFor({
 				line: stack.getLineNumber(),
 				column: stack.getColumnNumber(),
@@ -132,21 +130,21 @@ async function handlePrerenderError(err, env, stack, entry) {
 		} caused by using DOM or Web APIs.\n`
 	);
 	process.stderr.write(
-		`Pre-render runs in node and has no access to globals available in browsers.\n\n`
+		'Pre-render runs in node and has no access to globals available in browsers.\n\n'
 	);
 	process.stderr.write(
-		`Consider wrapping code producing error in: 'if (typeof window !== "undefined") { ... }'\n`
+		'Consider wrapping code producing error in: "if (typeof window !== "undefined") { ... }"\n'
 	);
 
 	if (methodName === 'componentWillMount') {
-		process.stderr.write(`or place logic in 'componentDidMount' method.\n`);
+		process.stderr.write('or place logic in "componentDidMount" method.\n');
 	}
 	process.stderr.write('\n');
 	process.stderr.write(
-		`Alternatively use 'preact build --no-prerender' to disable prerendering.\n\n`
+		'Alternatively use "preact build --no-prerender" to disable prerendering.\n\n'
 	);
 	process.stderr.write(
-		'See https://github.com/developit/preact-cli#pre-rendering for further information.'
+		'See https://github.com/preactjs/preact-cli#pre-rendering for further information.\n\n'
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Improves the error message when prerender fails because of code that ran in `node_modules/`

Before:
![image (17)](https://user-images.githubusercontent.com/202527/93202825-07e93f80-f75c-11ea-9d1e-e46574663ae8.png)

After:
![image](https://user-images.githubusercontent.com/202527/93202909-2c451c00-f75c-11ea-8a79-16800ea26277.png)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No

**Summary**

This improves the prerender error message in cases like the following:
```jsx
import { createBrowserHistory } from 'history'

<App>
  <Router history={createBrowserHistory()}> // breaks prerendering
  // [...]
```

Fixed code:
```jsx
import { createBrowserHistory, createMemoryHistory } from 'history'

<App>
  <Router history={
    typeof window !== 'undefined' 
        ? createBrowserHistory()
        : createMemoryHistory()
  }> 
  // [...]
```

**Does this PR introduce a breaking change?**

No

**Other information**

```
Environment Info:
  System:
    OS: Linux 4.15 Ubuntu 16.04.7 LTS (Xenial Xerus)
    CPU: (16) x64 Intel(R) Core(TM) i9-9900KS CPU @ 4.00GHz
  Binaries:
    Node: 14.8.0 - ~/.nvm/versions/node/v14.8.0/bin/node
    Yarn: 1.21.1 - /usr/bin/yarn
    npm: 6.14.7 - ~/.nvm/versions/node/v14.8.0/bin/npm
  Browsers:
    Chrome: 85.0.4183.102
    Firefox: 80.0.1
  npmPackages:
    preact: ^10.4.8 => 10.4.8 
    preact-cli: ^3.0.1 => 3.0.1 
    preact-render-to-string: ^5.1.10 => 5.1.10 
    preact-router: ^3.2.1 => 3.2.1 
```
