### PR TITLE
Feature: Watch mode without dev server 

### DIFF
--- a/.changeset/ten-ligers-develop.md
+++ b/.changeset/ten-ligers-develop.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': minor
+---
+
+This change allows a user to disable the Webpack dev server while using the CLI's 'watch' mode. Useful for developing apps for SSR as this is much quicker without the production optimizations and will auto-run on changes to the source.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ $ preact watch
     --template         Path to custom HTML template
     --refresh          Will use [`Preact-refresh`](https://github.com/JoviDeCroock/preact-refresh) to do hot-reloading
     --devServer        Determine if dev server should be enabled  (default true)
-    --ignore           Path relative to src to be ignored during watch if dev server is disabled
     -c, --config       Path to custom CLI config  (default preact.config.js)
     -H, --host         Set server hostname  (default 0.0.0.0)
     -p, --port         Set server port  (default 8080)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ $ preact watch
 
     --src              Specify source directory  (default src)
     --cwd              A directory to use instead of $PWD  (default .)
+    --devServer        Determine if dev server should be enabled  (default true)
+    --dest             Specify output directory if dev server is disabled  (default build)
+    --ignore           Path relative to src to be ignored during watch if dev server is disabled
     --esm              Builds ES-2015 bundles for your code  (default false)
     --clear            Clear the console (default true)
     --sw               Generate and attach a Service Worker  (default false)

--- a/README.md
+++ b/README.md
@@ -136,10 +136,8 @@ Spin up a development server with multiple features like `hot-module-replacement
 $ preact watch
 
     --src              Specify source directory  (default src)
-    --cwd              A directory to use instead of $PWD  (default .)
-    --devServer        Determine if dev server should be enabled  (default true)
     --dest             Specify output directory if dev server is disabled  (default build)
-    --ignore           Path relative to src to be ignored during watch if dev server is disabled
+    --cwd              A directory to use instead of $PWD  (default .)
     --esm              Builds ES-2015 bundles for your code  (default false)
     --clear            Clear the console (default true)
     --sw               Generate and attach a Service Worker  (default false)
@@ -153,6 +151,8 @@ $ preact watch
     --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
     --template         Path to custom HTML template
     --refresh          Will use [`Preact-refresh`](https://github.com/JoviDeCroock/preact-refresh) to do hot-reloading
+    --devServer        Determine if dev server should be enabled  (default true)
+    --ignore           Path relative to src to be ignored during watch if dev server is disabled
     -c, --config       Path to custom CLI config  (default preact.config.js)
     -H, --host         Set server hostname  (default 0.0.0.0)
     -p, --port         Set server port  (default 8080)

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -4,7 +4,7 @@ const { promisify } = require('util');
 const { warn } = require('../util');
 const runWebpack = require('../lib/webpack/run-webpack');
 
-const toBool = (val) => val !== void 0 || (val === 'false' ? false : val);
+const toBool = (val) => val === void 0 || (val === 'false' ? false : val);
 
 module.exports = async function (src, argv) {
 	if (argv.rhl) {
@@ -14,7 +14,8 @@ module.exports = async function (src, argv) {
 
 	argv.src = src || argv.src;
 	argv.production = false;
-	argv.prerender = toBool(argv.prerender);
+	argv.devServer = toBool(argv.devServer);
+	if (!argv.devServer) argv.prerender = true;
 
 	if (argv.https || process.env.HTTPS) {
 		let { key, cert, cacert } = argv;

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -1,5 +1,8 @@
-const runWebpack = require('../lib/webpack/run-webpack');
+const rimraf = require('rimraf');
+const { resolve } = require('path');
+const { promisify } = require('util');
 const { warn } = require('../util');
+const runWebpack = require('../lib/webpack/run-webpack');
 
 const toBool = (val) => val === void 0 || (val === 'false' ? false : val);
 
@@ -20,6 +23,11 @@ module.exports = async function (src, argv) {
 		} else {
 			warn('Reverting to `webpack-dev-server` internal certificate.');
 		}
+	}
+
+	if (argv.clean === void 0) {
+		let dest = resolve(argv.cwd, argv.dest);
+		await promisify(rimraf)(dest);
 	}
 
 	return runWebpack(argv, true);

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -12,9 +12,9 @@ module.exports = async function (src, argv) {
 		argv.refresh = argv.rhl;
 	}
 
-	argv.prerender = toBool(argv.prerender);
 	argv.src = src || argv.src;
 	argv.production = false;
+	argv.prerender = toBool(argv.prerender);
 
 	if (argv.https || process.env.HTTPS) {
 		let { key, cert, cacert } = argv;

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -1,11 +1,15 @@
 const runWebpack = require('../lib/webpack/run-webpack');
 const { warn } = require('../util');
 
+const toBool = (val) => val === void 0 || (val === 'false' ? false : val);
+
 module.exports = async function (src, argv) {
 	if (argv.rhl) {
 		delete argv.rhl;
 		argv.refresh = argv.rhl;
 	}
+
+	argv.prerender = toBool(argv.prerender);
 	argv.src = src || argv.src;
 	argv.production = false;
 

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -4,7 +4,7 @@ const { promisify } = require('util');
 const { warn } = require('../util');
 const runWebpack = require('../lib/webpack/run-webpack');
 
-const toBool = (val) => val === void 0 || (val === 'false' ? false : val);
+const toBool = (val) => val !== void 0 || (val === 'false' ? false : val);
 
 module.exports = async function (src, argv) {
 	if (argv.rhl) {

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -108,11 +108,6 @@ prog
 		false
 	)
 	.option('--devServer', 'Determine if dev server should be enabled', true)
-	.option(
-		'--ignore',
-		'Path relative to src to be ignored during watch if dev server is disabled',
-		''
-	)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-H, --host', 'Set server hostname', '0.0.0.0')
 	.option('-p, --port', 'Set server port', 8080)

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -80,6 +80,18 @@ prog
 	.option('--src', 'Specify source directory', 'src')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
 	.option('--esm', 'Builds ES-2015 bundles for your code', false)
+	.option('--devServer', 'Determine if dev server should be enabled', true)
+	.option(
+		'--dest',
+		'Specify output directory if dev server is disabled',
+		'build'
+	)
+	.option(
+		'--ignore',
+		'Path relative to src to be ignored during watch if dev server is disabled',
+		''
+	)
+	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -78,19 +78,13 @@ prog
 	.command('watch [src]')
 	.describe('Start a live-reload server for development')
 	.option('--src', 'Specify source directory', 'src')
-	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code', false)
-	.option('--devServer', 'Determine if dev server should be enabled', true)
 	.option(
 		'--dest',
 		'Specify output directory if dev server is disabled',
 		'build'
 	)
-	.option(
-		'--ignore',
-		'Path relative to src to be ignored during watch if dev server is disabled',
-		''
-	)
+	.option('--cwd', 'A directory to use instead of $PWD', '.')
+	.option('--esm', 'Builds ES-2015 bundles for your code', false)
 	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
@@ -112,6 +106,12 @@ prog
 		'--refresh',
 		'Enables experimental preact-refresh functionality',
 		false
+	)
+	.option('--devServer', 'Determine if dev server should be enabled', true)
+	.option(
+		'--ignore',
+		'Path relative to src to be ignored during watch if dev server is disabled',
+		''
 	)
 	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
 	.option('-H, --host', 'Set server hostname', '0.0.0.0')

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -85,7 +85,6 @@ prog
 	)
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
 	.option('--esm', 'Builds ES-2015 bundles for your code', false)
-	.option('--esm', 'Builds ES-2015 bundles for your code.', false)
 	.option('--clear', 'Clear the console', true)
 	.option('--sw', 'Generate and attach a Service Worker', undefined)
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -136,7 +136,7 @@ function runCompiler(compiler) {
 function runWatch(compiler, options = {}) {
 	return new Promise((res, rej) => {
 		compiler.watch(options, (err, stats) => {
-			showStats(stats, true);
+			showStats(stats, false);
 
 			if (err || (stats && stats.hasErrors())) {
 				rej(`${red('\n\nBuild failed! \n\n')} ${err || ''}`);

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -81,11 +81,11 @@ async function devBuild(env) {
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
 
-		if (!shouldRunDevServer) return res(runWatch(compiler));
-
 		let c = Object.assign({}, config.devServer, {
 			stats: { colors: true },
 		});
+
+		if (!shouldRunDevServer) return res(runWatch(compiler, c));
 
 		let server = new DevServer(compiler, c);
 		server.listen(port);

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -16,6 +16,17 @@ async function devBuild(env) {
 
 	await transformConfig(env, config);
 
+	const shouldRunDevServer = env.devServer;
+
+	if (!shouldRunDevServer && env.prerender) {
+		let ssrConfig = serverConfig(env);
+		await transformConfig(env, ssrConfig, true);
+		let serverCompiler = webpack(ssrConfig);
+		await runWatch(serverCompiler, {
+			ignored: env.source(env.ignore),
+		});
+	}
+
 	let userPort =
 		parseInt(process.env.PORT || config.devServer.port, 10) || 8080;
 	let port = await getPort({ port: userPort });
@@ -39,6 +50,8 @@ async function devBuild(env) {
 		});
 
 		compiler.hooks.done.tap('CliDevPlugin', (stats) => {
+			if (!shouldRunDevServer) return;
+
 			let devServer = config.devServer;
 			let protocol = process.env.HTTPS || devServer.https ? 'https' : 'http';
 			let host = process.env.HOST || devServer.host || 'localhost';
@@ -70,6 +83,13 @@ async function devBuild(env) {
 		});
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
+
+		if (!shouldRunDevServer)
+			return res(
+				runWatch(compiler, {
+					ignored: env.source(env.ignore),
+				})
+			);
 
 		let c = Object.assign({}, config.devServer, {
 			stats: { colors: true },
@@ -110,6 +130,20 @@ async function prodBuild(env) {
 function runCompiler(compiler) {
 	return new Promise((res, rej) => {
 		compiler.run((err, stats) => {
+			showStats(stats, true);
+
+			if (err || (stats && stats.hasErrors())) {
+				rej(`${red('\n\nBuild failed! \n\n')} ${err || ''}`);
+			}
+
+			res(stats);
+		});
+	});
+}
+
+function runWatch(compiler, options = {}) {
+	return new Promise((res, rej) => {
+		compiler.watch(options, (err, stats) => {
 			showStats(stats, true);
 
 			if (err || (stats && stats.hasErrors())) {

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -22,9 +22,7 @@ async function devBuild(env) {
 		let ssrConfig = serverConfig(env);
 		await transformConfig(env, ssrConfig, true);
 		let serverCompiler = webpack(ssrConfig);
-		await runWatch(serverCompiler, {
-			ignored: env.source(env.ignore),
-		});
+		await runWatch(serverCompiler);
 	}
 
 	let userPort =
@@ -84,12 +82,7 @@ async function devBuild(env) {
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
 
-		if (!shouldRunDevServer)
-			return res(
-				runWatch(compiler, {
-					ignored: env.source(env.ignore),
-				})
-			);
+		if (!shouldRunDevServer) return res(runWatch(compiler));
 
 		let c = Object.assign({}, config.devServer, {
 			stats: { colors: true },

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -13,7 +13,6 @@ const { error, isDir, warn } = require('../../util');
 
 async function devBuild(env) {
 	let config = await clientConfig(env);
-
 	await transformConfig(env, config);
 
 	const shouldRunDevServer = env.devServer;

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -71,7 +71,7 @@ function getSassConfiguration(...includePaths) {
 }
 
 module.exports = function (env) {
-	const { cwd, isProd, isWatch, src, source } = env;
+	const { cwd, isProd, isWatch, devServer, src, source } = env;
 	const babelConfigFile = env.babelConfig || '.babelrc';
 	const IS_SOURCE_PREACT_X_OR_ABOVE = isInstalledVersionPreactXOrAbove(cwd);
 	// Apply base-level `env` values
@@ -227,7 +227,7 @@ module.exports = function (env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					include: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						devServer ? 'style-loader' : MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {
@@ -253,7 +253,7 @@ module.exports = function (env) {
 					test: /\.(p?css|less|s[ac]ss|styl)$/,
 					exclude: [source('components'), source('routes')],
 					use: [
-						isWatch ? 'style-loader' : MiniCssExtractPlugin.loader,
+						devServer ? 'style-loader' : MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -26,7 +26,7 @@ const cleanFilename = (name) =>
 	);
 
 async function clientConfig(env) {
-	const { isProd, source, src, cwd, devServer /*, port? */ } = env;
+	const { isProd, source, src, cwd /*, port? */ } = env;
 	const IS_SOURCE_PREACT_X_OR_ABOVE = isInstalledVersionPreactXOrAbove(cwd);
 	const asyncLoader = IS_SOURCE_PREACT_X_OR_ABOVE
 		? require.resolve('@preact/async-loader')
@@ -184,7 +184,7 @@ function isProd(config) {
 				'process.env.ESM': config.esm,
 				'process.env.PRERENDER': config.prerender,
 			}),
-			new SizePlugin()
+			new SizePlugin(),
 		],
 
 		optimization: {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -26,7 +26,7 @@ const cleanFilename = (name) =>
 	);
 
 async function clientConfig(env) {
-	const { isProd, source, src, cwd /*, port? */ } = env;
+	const { isProd, source, src, cwd, devServer /*, port? */ } = env;
 	const IS_SOURCE_PREACT_X_OR_ABOVE = isInstalledVersionPreactXOrAbove(cwd);
 	const asyncLoader = IS_SOURCE_PREACT_X_OR_ABOVE
 		? require.resolve('@preact/async-loader')

--- a/packages/cli/tests/lib/cli.js
+++ b/packages/cli/tests/lib/cli.js
@@ -48,10 +48,12 @@ exports.build = function (cwd, options, installNodeModules = false) {
 	return cmd.build(argv.src, Object.assign({}, opts, options));
 };
 
-exports.watch = function (cwd, port, host = '127.0.0.1') {
-	let opts = Object.assign(
-		{ cwd, host, port, https: false, devServer: true },
-		argv
-	);
+exports.watch = function (cwd, port, host = '127.0.0.1', devServer = true) {
+	if (!devServer) {
+		mkdirp.sync(join(cwd, 'node_modules')); // ensure exists, avoid exit()
+		linkPackage('preact', root, cwd);
+		linkPackage('preact-render-to-string', root, cwd);
+	}
+	let opts = Object.assign({ cwd, host, port, https: false, devServer }, argv);
 	return cmd.watch(argv.src, opts);
 };

--- a/packages/cli/tests/lib/cli.js
+++ b/packages/cli/tests/lib/cli.js
@@ -20,7 +20,7 @@ const argv = {
 	'inline-css': true,
 };
 
-exports.create = async function(template, name) {
+exports.create = async function (template, name) {
 	let dest = tmpDir();
 	name = name || `test-${template}`;
 
@@ -35,7 +35,7 @@ exports.create = async function(template, name) {
 	return dest;
 };
 
-exports.build = function(cwd, options, installNodeModules = false) {
+exports.build = function (cwd, options, installNodeModules = false) {
 	if (!installNodeModules) {
 		mkdirp.sync(join(cwd, 'node_modules')); // ensure exists, avoid exit()
 		linkPackage('preact', root, cwd);
@@ -48,7 +48,10 @@ exports.build = function(cwd, options, installNodeModules = false) {
 	return cmd.build(argv.src, Object.assign({}, opts, options));
 };
 
-exports.watch = function(cwd, port, host = '127.0.0.1') {
-	let opts = Object.assign({ cwd, host, port, https: false }, argv);
+exports.watch = function (cwd, port, host = '127.0.0.1') {
+	let opts = Object.assign(
+		{ cwd, host, port, https: false, devServer: true },
+		argv
+	);
 	return cmd.watch(argv.src, opts);
 };

--- a/packages/cli/tests/watch.test.js
+++ b/packages/cli/tests/watch.test.js
@@ -2,6 +2,7 @@ const fs = require('../lib/fs');
 const { resolve } = require('path');
 const startChrome = require('./lib/chrome');
 const { create, watch } = require('./lib/cli');
+const { sleep } = require('./lib/utils');
 
 const { loadPage, waitUntilExpression } = startChrome;
 let chrome, server;
@@ -32,5 +33,29 @@ describe('preact', () => {
 		);
 
 		server.close();
+	});
+
+	it('should hot reload and prerender without a development server', async () => {
+		let dir = await create('default');
+		await watch(dir, undefined, undefined, false);
+
+		const initialContent = await fs.readFile(
+			resolve(dir, './build/bundle.js'),
+			'utf8'
+		);
+
+		let header = resolve(dir, './src/components/header/index.js');
+		let original = await fs.readFile(header, 'utf8');
+		let update = original.replace('<h1>Preact App</h1>', '<h1>Test App</h1>');
+		await fs.writeFile(header, update);
+
+		await sleep(1500); // wait for a rebuild
+		const updatedContent = await fs.readFile(
+			resolve(dir, './build/bundle.js'),
+			'utf8'
+		);
+
+		expect(updatedContent).not.toEqual(initialContent);
+		expect(updatedContent).not.toContain('Preact App');
 	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

Yes. I added a test under `watch.test.js` that will run the file watcher and check to see if the built output is updated after a change occurs to the source. I figure this approach is simpler than the alternatives and still ensures the functionality works. So long as the built output changes the feature should be fine. I don't think we need a browser test. 

**Summary**

This builds upon #1264 which leads back to & would close #1248.

Currently, the experience for developing SSR apps using the Preact CLI isn't great. To produce a bundle that can be used a developer needs to run the full production build and then rerun it on every change. This is slow and un-automated.

A solution, as pointed out by @oliverstr, is to provide an option to disable the dev server in `watch` mode. Any changes to the source would have the CLI rebuild and developers can consume the build in any way that they please.

@oliverstr's PR for implementing this feature (#1264) has been untouched since June 29th so I figure at this point it is fair to step in and try to complete. His PR had a few issues, besides being behind the current head, namely, it would not clear the `build/` directory, leading to a large build up of temporary files, it ignored changes to `src/*` by default, and it could not handle CSS imports without wrapping them in a window check (`if (typeof window !== "undefined") { ... }`). I have fixed all three of these issues and a few more that popped up along the way to finish off his feature. 

You can use the following repo to try this out, though you'll need to bring your own CLI copy with linking or relative paths. Simple server set up with Polka and Nodemon. Simply run `yarn serve:dev` in one terminal window and `yarn serve` in another. `serve:dev` starts the CLI watch mode, `serve` starts Polka with Nodemon. Nothing fancy.

[ryanchristian4427/preact-cli-watch-without-devserver](https://github.com/RyanChristian4427/preact-cli-watch-without-devserver)

**Does this PR introduce a breaking change?**

No breaking changes. This feature is behind a flag.