### PR TITLE
refactor: Remove size tracking of SSR build

### DIFF
--- a/.changeset/many-chairs-add.md
+++ b/.changeset/many-chairs-add.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+This disable SSR size tracking. This stops `size-plugin-ssr.json` from being generated and stops file sizes from being reported to the developer.

--- a/packages/cli/lib/lib/webpack/webpack-server-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-server-config.js
@@ -1,5 +1,4 @@
 const { resolve } = require('path');
-const SizePlugin = require('size-plugin');
 const merge = require('webpack-merge');
 const baseConfig = require('./webpack-base-config');
 
@@ -24,9 +23,6 @@ function serverConfig(env) {
 				async: resolve(__dirname, './dummy-loader'),
 			},
 		},
-		plugins: [
-			new SizePlugin({ filename: 'size-plugin-ssr.json' }),
-		]
 	};
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Minor refactor

**Did you add tests for your changes?**

No

**Summary**

#1407 introduced a `size-plugin-ssr.json`. This is rather pointless to measure and doesn't have much value to the end user. This PR removes it.

**Does this PR introduce a breaking change?**

No