### PR TITLE
Fix: Include ReadMe when publishing package

### DIFF
--- a/.changeset/funny-falcons-pump.md
+++ b/.changeset/funny-falcons-pump.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Change ensures root ReadMe is bundled with CLI package on publish

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "test": "lerna run test --stream",
     "prettier": "prettier --write **/*.{js,ts,tsx,json,css,scss,md,yml}",
     "lint": "eslint .",
-    "prepack": "ncp README.md packages/cli/",
-    "postpack": "rimraf packages/cli/README.md",
     "changeset": "changeset",
     "release": "changeset publish"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prettier": "prettier --write **/*.{js,ts,tsx,json,css,scss,md,yml}",
     "lint": "eslint .",
     "changeset": "changeset",
-    "release": "changeset publish"
+    "release": "ncp README.md packages/cli/README.md && changeset publish && rimraf packages/cli/README.md"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.2.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,9 +9,7 @@
 	},
 	"scripts": {
 		"pretest": "rimraf ./tests/output",
-		"test": "jest --forceExit",
-		"prepack": "ncp ../../README.md README.md",
-		"postpack": "rimraf README.md"
+		"test": "jest --forceExit"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,9 @@
 	},
 	"scripts": {
 		"pretest": "rimraf ./tests/output",
-		"test": "jest --forceExit"
+		"test": "jest --forceExit",
+		"prepack": "ncp ../../README.md README.md",
+		"postpack": "rimraf README.md"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix when publishing

**Did you add tests for your changes?**

No

**Summary**

Currently, [the ReadMe is not included with the package when publishing it](https://www.npmjs.com/package/preact-cli/v/3.0.2). This can be quite inconvenient as there's no documentation to go with the package.

It seems [the last time the readme was included was back with `3.0.0-next.1`](https://www.npmjs.com/package/preact-cli/v/3.0.0-next.1). While there was an attempt to fix this with #806, it doesn't seem to have worked. I'm going to guess that this is because publishing happens from with `packages/cli` rather than the root.

This moves the copy & clean up commands into the cli package itself.

**Does this PR introduce a breaking change?**

No