### PR TITLE
Get url from props for prerender-data-provider

### DIFF
--- a/packages/prerender-data-provider/src/hook.js
+++ b/packages/prerender-data-provider/src/hook.js
@@ -1,5 +1,5 @@
 import { useContext, useState } from 'preact/hooks';
-import { normalizeUrl, getPrerenderdata, checkProps } from './utils';
+import { normalizeUrl, getPrerenderdata, checkProps, getUrlFromProps } from './utils';
 import { PrerenderDataContext } from './context';
 import { PRERENDER_DATA_FILE_NAME } from './constants';
 
@@ -12,6 +12,7 @@ function usePrerenderData(props, doAutomaticFetch = true) {
 	});
 	const contextValue = useContext(PrerenderDataContext);
 	checkProps(props);
+	props.url = getUrlFromProps(props);
 
 	async function fetchPreRenderData() {
 		setState({

--- a/packages/prerender-data-provider/src/utils.js
+++ b/packages/prerender-data-provider/src/utils.js
@@ -23,9 +23,9 @@ function checkProps(props) {
 
 function getUrlFromProps(props) {
 	let url = props.path;
-	Object.entries(props.matches).forEach(([key, path], i) => {
+	Object.entries(props.matches).forEach(([key, path]) => {
 		url = url.replace(`:${key}`, path);
-	})
+	});
 	return url;
 }
 

--- a/packages/prerender-data-provider/src/utils.js
+++ b/packages/prerender-data-provider/src/utils.js
@@ -21,4 +21,12 @@ function checkProps(props) {
 	}
 }
 
-export { normalizeUrl, getPrerenderdata, checkProps };
+function getUrlFromProps(props) {
+	let url = props.path;
+	Object.entries(props.matches).forEach(([key, path], i) => {
+		url = url.replace(`:${key}`, path);
+	})
+	return url;
+}
+
+export { normalizeUrl, getPrerenderdata, checkProps, getUrlFromProps };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**Summary**
When example a query is included in the URL path, prerender-data-provider returns null as it doesn't check if the path exists without the query. Now it remaps the URL using given props matches.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A
