### PR TITLE
Allow only valid options for commands

### DIFF
--- a/.changeset/ninety-drinks-wave.md
+++ b/.changeset/ninety-drinks-wave.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Allow only valid options for commands.

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -3,10 +3,12 @@ const { resolve } = require('path');
 const { promisify } = require('util');
 const { isDir, error } = require('../util');
 const runWebpack = require('../lib/webpack/run-webpack');
+const { validateArgs } = require('./validate-args');
 
 const toBool = val => val === void 0 || (val === 'false' ? false : val);
 
-module.exports = async function (src, argv) {
+async function command(src, argv) {
+	validateArgs(argv, options, 'build');
 	argv.src = src || argv.src;
 	// add `default:true`s, `--no-*` disables
 	argv.prerender = toBool(argv.prerender);
@@ -32,4 +34,83 @@ module.exports = async function (src, argv) {
 	if (argv.json) {
 		await runWebpack.writeJsonStats(stats);
 	}
+}
+
+const options = [
+	{
+		name: '--src',
+		description: 'Specify source directory',
+		default: 'src',
+	},
+	{
+		name: '--dest',
+		description: 'Specify output directory',
+		default: 'build',
+	},
+	{
+		name: '--cwd',
+		description: 'A directory to use instead of $PWD',
+		default: '.',
+	},
+	{
+		name: '--esm',
+		description: 'Builds ES-2015 bundles for your code',
+		default: true,
+	},
+	{
+		name: '--sw',
+		description: 'Generate and attach a Service Worker',
+		default: true,
+	},
+	{
+		name: '--babelConfig',
+		description: 'Path to custom Babel config',
+		default: '.babelrc',
+	},
+	{
+		name: '--json',
+		description: 'Generate build stats for bundle analysis',
+	},
+	{
+		name: '--template',
+		description: 'Path to custom HTML template',
+	},
+	{
+		name: '--preload',
+		description: 'Adds preload tags to the document its assets',
+		default: false,
+	},
+	{
+		name: '--analyze',
+		description: 'Launch interactive Analyzer to inspect production bundle(s)',
+	},
+	{
+		name: '--prerenderUrls',
+		description: 'Path to pre-rendered routes config',
+		default: 'prerender-urls.json',
+	},
+	{
+		name: '--brotli',
+		description: 'Builds brotli compressed bundles of javascript',
+		default: false,
+	},
+	{
+		name: '--inline-css',
+		description: 'Adds critical css to the prerendered markup',
+		default: true,
+	},
+	{
+		name: '-c, --config',
+		description: 'Path to custom CLI config',
+		default: 'preact.config.js',
+	},
+	{
+		name: '-v, --verbose',
+		description: 'Verbose output',
+	},
+];
+
+module.exports = {
+	command,
+	options,
 };

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -28,6 +28,7 @@ const {
 	FALLBACK_TEMPLATE_OPTIONS,
 } = require('../constants');
 const { addScripts, install, initGit } = require('../lib/setup');
+const { validateArgs } = require('./validate-args');
 
 const ORG = 'preactjs-templates';
 const RGX = /\.(woff2?|ttf|eot|jpe?g|ico|png|gif|webp|mp4|mov|ogg|webm)(\?.*)?$/i;
@@ -163,7 +164,8 @@ async function copyFileToDestination(srcPath, destPath, force = false) {
 	}
 }
 
-module.exports = async function (repo, dest, argv) {
+async function command(repo, dest, argv) {
+	validateArgs(argv, options, 'create');
 	// Prompt if incomplete data
 	if (!repo || !dest) {
 		const templates = await fetchTemplates();
@@ -381,4 +383,51 @@ module.exports = async function (repo, dest, argv) {
 			${green(pfx + ' serve')}
 	`) + '\n'
 	);
+}
+
+const options = [
+	{
+		name: '--name',
+		description: 'The application name',
+	},
+	{
+		name: '--cwd',
+		description: 'A directory to use instead of $PWD',
+		default: '.',
+	},
+	{
+		name: '--force',
+		description: 'Force destination output; will override!',
+		default: false,
+	},
+	{
+		name: '--install',
+		description: 'Install dependencies',
+		default: true,
+	},
+	{
+		name: '--yarn',
+		description: 'Use `yarn` instead of `npm`',
+		default: false,
+	},
+	{
+		name: '--git',
+		description: 'Initialize git repository',
+		default: false,
+	},
+	{
+		name: '--license',
+		description: 'License type',
+		default: 'MIT',
+	},
+	{
+		name: '-v, --verbose',
+		description: 'Verbose output',
+		default: false,
+	},
+];
+
+module.exports = {
+	command,
+	options,
 };

--- a/packages/cli/lib/commands/index.js
+++ b/packages/cli/lib/commands/index.js
@@ -1,4 +1,14 @@
-exports.build = require('./build');
-exports.create = require('./create');
-exports.list = require('./list');
-exports.watch = require('./watch');
+const { command: build, options: buildOptions } = require('./build');
+const { command: create, options: createOptions } = require('./create');
+const list = require('./list');
+const { command: watch, options: watchOptions } = require('./watch');
+
+module.exports = {
+	build,
+	buildOptions,
+	create,
+	createOptions,
+	list,
+	watch,
+	watchOptions,
+};

--- a/packages/cli/lib/commands/validate-args.js
+++ b/packages/cli/lib/commands/validate-args.js
@@ -1,0 +1,29 @@
+const { error } = require('../util');
+
+function validateArgs(argv, options, command) {
+	let normalizedOptions = options.map(option => option.name.split(',')).flat(1);
+	normalizedOptions = normalizedOptions.map(option => {
+		option = option.trim();
+		if (option.startsWith('--')) {
+			return option.substr(2);
+		} else if (option.startsWith('-')) {
+			return option.substr(1);
+		}
+	});
+	for (const arg in argv) {
+		if (arg === '_') {
+			// ignore this arg
+			continue;
+		}
+		if (!normalizedOptions.includes(arg)) {
+			error(
+				`Invalid argument ${arg} passed to ${command}. Please refer to 'preact ${command} --help' for full list of options.\n\n`
+			);
+			throw new Error('Invalid argunment found.');
+		}
+	}
+}
+
+module.exports = {
+	validateArgs,
+};

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -1,7 +1,9 @@
 const runWebpack = require('../lib/webpack/run-webpack');
 const { warn } = require('../util');
+const { validateArgs } = require('./validate-args');
 
-module.exports = async function (src, argv) {
+async function command(src, argv) {
+	validateArgs(argv, options, 'watch');
 	if (argv.rhl) {
 		delete argv.rhl;
 		argv.refresh = argv.rhl;
@@ -19,4 +21,100 @@ module.exports = async function (src, argv) {
 	}
 
 	return runWebpack(argv, true);
+}
+
+const options = [
+	{
+		name: '--src',
+		description: 'Specify source directory',
+		default: 'src',
+	},
+	{
+		name: '--cwd',
+		description: 'A directory to use instead of $PWD',
+		default: '.',
+	},
+	{
+		name: '--esm',
+		description: 'Builds ES-2015 bundles for your code',
+		default: false,
+	},
+	{
+		name: '--clear',
+		description: 'Clear the console',
+		default: true,
+	},
+	{
+		name: '--sw',
+		description: 'Generate and attach a Service Worker',
+		default: undefined,
+	},
+	{
+		name: '--babelConfig',
+		description: 'Path to custom Babel config',
+		default: '.babelrc',
+	},
+	{
+		name: '--rhl',
+		description: '(Deprecated) use --refresh instead',
+		default: false,
+	},
+	{
+		name: '--json',
+		description: 'Generate build stats for bundle analysis',
+	},
+	{
+		name: '--https',
+		description: 'Run server with HTTPS protocol',
+	},
+	{
+		name: '--key',
+		description: 'Path to PEM key for custom SSL certificate',
+	},
+	{
+		name: '--cert',
+		description: 'Path to custom SSL certificate',
+	},
+	{
+		name: '--cacert',
+		description: 'Path to optional CA certificate override',
+	},
+	{
+		name: '--prerender',
+		description: 'Pre-render static content on first run',
+	},
+	{
+		name: '--prerenderUrls',
+		description: 'Path to pre-rendered routes config',
+		default: 'prerender-urls.json',
+	},
+	{
+		name: '--template',
+		description: 'Path to custom HTML template',
+	},
+	{
+		name: '--refresh',
+		description: 'Enables experimental preact-refresh functionality',
+		default: false,
+	},
+	{
+		name: '-c, --config',
+		description: 'Path to custom CLI config',
+		default: 'preact.config.js',
+	},
+	{
+		name: '-H, --host',
+		description: 'Set server hostname',
+		default: '0.0.0.0',
+	},
+	{
+		name: '-p, --port',
+		description: 'Set server port',
+		default: 8080,
+	},
+];
+
+module.exports = {
+	command,
+	options,
 };

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -30,81 +30,33 @@ process.on('unhandledRejection', err => {
 
 let prog = sade('preact').version(pkg.version);
 
-prog
+const buildCommand = prog
 	.command('build [src]')
 	.describe(
 		'Create a production build. You can disable "default: true" flags by prefixing them with --no-<option>'
-	)
-	.option('--src', 'Specify source directory', 'src')
-	.option('--dest', 'Specify output directory', 'build')
-	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code', true)
-	.option('--sw', 'Generate and attach a Service Worker', true)
-	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
-	.option('--json', 'Generate build stats for bundle analysis')
-	.option('--template', 'Path to custom HTML template')
-	.option('--preload', 'Adds preload tags to the document its assets', false)
-	.option(
-		'--analyze',
-		'Launch interactive Analyzer to inspect production bundle(s)'
-	)
-	.option(
-		'--prerenderUrls',
-		'Path to pre-rendered routes config',
-		'prerender-urls.json'
-	)
-	.option('--brotli', 'Builds brotli compressed bundles of javascript', false)
-	.option('--inline-css', 'Adds critical css to the prerendered markup', true)
-	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
-	.option('-v, --verbose', 'Verbose output')
-	.action(commands.build);
+	);
+commands.buildOptions.forEach(option => {
+	buildCommand.option(option.name, option.description, option.default);
+});
+buildCommand.action(commands.build);
 
-prog
+const createCommand = prog
 	.command('create [template] [dest]')
-	.describe('Create a new application')
-	.option('--name', 'The application name')
-	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--force', 'Force destination output; will override!', false)
-	.option('--install', 'Install dependencies', true)
-	.option('--yarn', 'Use `yarn` instead of `npm`', false)
-	.option('--git', 'Initialize git repository', false)
-	.option('--license', 'License type', 'MIT')
-	.option('-v, --verbose', 'Verbose output', false)
-	.action(commands.create);
+	.describe('Create a new application');
+commands.createOptions.forEach(option => {
+	createCommand.option(option.name, option.description, option.default);
+});
+createCommand.action(commands.create);
+
+const watchCommand = prog
+	.command('watch [src]')
+	.describe('Start a live-reload server for development');
+commands.watchOptions.forEach(option => {
+	watchCommand.option(option.name, option.description, option.default);
+});
+watchCommand.action(commands.watch);
 
 prog.command('list').describe('List official templates').action(commands.list);
-
-prog
-	.command('watch [src]')
-	.describe('Start a live-reload server for development')
-	.option('--src', 'Specify source directory', 'src')
-	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code', false)
-	.option('--clear', 'Clear the console', true)
-	.option('--sw', 'Generate and attach a Service Worker', undefined)
-	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
-	.option('--rhl', '(Deprecated) use --refresh instead', false)
-	.option('--json', 'Generate build stats for bundle analysis')
-	.option('--https', 'Run server with HTTPS protocol')
-	.option('--key', 'Path to PEM key for custom SSL certificate')
-	.option('--cert', 'Path to custom SSL certificate')
-	.option('--cacert', 'Path to optional CA certificate override')
-	.option('--prerender', 'Pre-render static content on first run')
-	.option(
-		'--prerenderUrls',
-		'Path to pre-rendered routes config',
-		'prerender-urls.json'
-	)
-	.option('--template', 'Path to custom HTML template')
-	.option(
-		'--refresh',
-		'Enables experimental preact-refresh functionality',
-		false
-	)
-	.option('-c, --config', 'Path to custom CLI config', 'preact.config.js')
-	.option('-H, --host', 'Set server hostname', '0.0.0.0')
-	.option('-p, --port', 'Set server port', 8080)
-	.action(commands.watch);
 
 prog
 	.command('info')

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -50,6 +50,14 @@ function testMatch(src, tar) {
 }
 
 describe('preact build', () => {
+	let mockExit;
+	beforeAll(async () => {
+		mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+	});
+
+	afterAll(async () => {
+		mockExit.mockRestore();
+	});
 	ours.forEach(key => {
 		it(`builds the '${key}' output`, async () => {
 			let dir = await create(key);
@@ -233,5 +241,13 @@ describe('preact build', () => {
 		let html = await readFile(file, 'utf-8');
 
 		looksLike(html, images.templateReplaced);
+	});
+
+	it('should error out for invalid argument', async () => {
+		let dir = await subject('custom-template-3');
+		expect(build(dir, { 'service-worker': false })).rejects.toEqual(
+			new Error('Invalid argunment found.')
+		);
+		expect(mockExit).toHaveBeenCalledWith(1);
 	});
 });

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -50,14 +50,6 @@ function testMatch(src, tar) {
 }
 
 describe('preact build', () => {
-	let mockExit;
-	beforeAll(async () => {
-		mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
-	});
-
-	afterAll(async () => {
-		mockExit.mockRestore();
-	});
 	ours.forEach(key => {
 		it(`builds the '${key}' output`, async () => {
 			let dir = await create(key);
@@ -245,9 +237,11 @@ describe('preact build', () => {
 
 	it('should error out for invalid argument', async () => {
 		let dir = await subject('custom-template-3');
+		const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
 		expect(build(dir, { 'service-worker': false })).rejects.toEqual(
 			new Error('Invalid argunment found.')
 		);
+		mockExit.mockRestore();
 		expect(mockExit).toHaveBeenCalledWith(1);
 	});
 });

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -241,7 +241,7 @@ describe('preact build', () => {
 		expect(build(dir, { 'service-worker': false })).rejects.toEqual(
 			new Error('Invalid argunment found.')
 		);
-		mockExit.mockRestore();
 		expect(mockExit).toHaveBeenCalledWith(1);
+		mockExit.mockRestore();
 	});
 });

--- a/packages/cli/tests/lib/cli.js
+++ b/packages/cli/tests/lib/cli.js
@@ -49,6 +49,9 @@ exports.build = function (cwd, options, installNodeModules = false) {
 };
 
 exports.watch = function (cwd, port, host = '127.0.0.1') {
-	let opts = Object.assign({ cwd, host, port, https: false }, argv);
+	const args = { ...argv };
+	delete args.dest;
+	delete args['inline-css'];
+	let opts = Object.assign({ cwd, host, port, https: false }, args);
 	return cmd.watch(argv.src, opts);
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This now throws error if the user passes invalid argument around `build`, `create` or `watch`.

**Did you add tests for your changes?**

Yes

**Summary**

Sample
```
$ mypreact watch --refresher
✖ ERROR Invalid argument refresher passed to watch. Please refer to 'preact watch --help' for full list of options.

$ mypreact build --no-service-worker
✖ ERROR Invalid argument service-worker passed to build. Please refer to 'preact build --help' for full list of options.
```

**Does this PR introduce a breaking change?**
No.