### PR TITLE
Refactor: Remove 'sw-debug.js' from prod output

### DIFF
--- a/.changeset/fair-ants-deny.md
+++ b/.changeset/fair-ants-deny.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+No longer copies 'sw-debug.js' to output directory on prod builds. No functional changes, as it was not used.

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -92,7 +92,7 @@ async function clientConfig(env) {
 					// copy any static files
 					existsSync(source('assets')) && { from: 'assets', to: 'assets' },
 					// copy sw-debug
-					{
+					!isProd && {
 						from: resolve(__dirname, '../../resources/sw-debug.js'),
 						to: 'sw-debug.js',
 					},
@@ -120,13 +120,9 @@ function getBabelEsmPlugin(config) {
 				beforeStartExecution: (plugins, newConfig) => {
 					const babelPlugins = newConfig.plugins;
 					newConfig.plugins = babelPlugins.filter(plugin => {
-						if (
-							Array.isArray(plugin) &&
-							plugin[0].indexOf('fast-async') !== -1
-						) {
-							return false;
-						}
-						return true;
+						return !(
+							Array.isArray(plugin) && plugin[0].indexOf('fast-async') !== -1
+						);
 					});
 					plugins.forEach(plugin => {
 						if (

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -120,9 +120,13 @@ function getBabelEsmPlugin(config) {
 				beforeStartExecution: (plugins, newConfig) => {
 					const babelPlugins = newConfig.plugins;
 					newConfig.plugins = babelPlugins.filter(plugin => {
-						return !(
-							Array.isArray(plugin) && plugin[0].indexOf('fast-async') !== -1
-						);
+						if (
+							Array.isArray(plugin) &&
+							plugin[0].indexOf('fast-async') !== -1
+						) {
+							return false;
+						}
+						return true;
 					});
 					plugins.forEach(plugin => {
 						if (

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -30,7 +30,6 @@ exports.default = exports.full = Object.assign({}, common, {
 	'ssr-build/ssr-bundle.6e806.css.map': 1250,
 	'ssr-build/ssr-bundle.js': 9976,
 	'ssr-build/ssr-bundle.js.map': 30887,
-	'sw-debug.js': 775,
 });
 exports['default-esm'] = exports.full = Object.assign({}, exports.default, {
 	'bundle.*.esm.js': 21135,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Edit to build output

**Did you add tests for your changes?**

I updated existing tests

**Summary**

Closes #1477

User wanted to keep `sw-debug.js` out of builds when specifying `--no-sw`. We already didn't use the debug service worker on prod builds, but copied the file regardless. 

This disables the debug service worker from being copied on production builds. I could add another check to make sure it's not copied on dev builds, but I feel like that's unnecessary. So long as the logic to keep it from being used is sound, we don't really need to worry about the copying of an extra file for dev.

**Does this PR introduce a breaking change?**

No