### PR TITLE
Fix/prerender arg validation

### DIFF
--- a/.changeset/tender-insects-explain.md
+++ b/.changeset/tender-insects-explain.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Adds the 'prerender' argument to the list of arguments to be validated against

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ $ preact build
     --template         Path to custom HTML template
     --preload          Adds preload tags to the document its assets  (default false)
     --analyze          Launch interactive Analyzer to inspect production bundle(s)
+    --prerender        Renders route(s) into generated static HTML  (default true)
     --prerenderUrls    Path to pre-rendered routes config  (default prerender-urls.json)
     --brotli           Adds brotli redirects to the service worker  (default false)
     --inline-css       Adds critical css to the prerendered markup  (default true)

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -56,6 +56,11 @@ const options = [
 		description: 'Launch interactive Analyzer to inspect production bundle(s)',
 	},
 	{
+		name: '--prerender',
+		description: 'Renders route(s) into generated static HTML',
+		default: true,
+	},
+	{
 		name: '--prerenderUrls',
 		description: 'Path to pre-rendered routes config',
 		default: 'prerender-urls.json',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

Closes #1489

The `prerender` arg was missing from list of acceptable arguments to `preact build`. This meant users could not disable it with `--no-prerender`.

**Does this PR introduce a breaking change?**

No
