### PR TITLE
Fix Node 10 support

### DIFF
--- a/packages/cli/lib/commands/validate-args.js
+++ b/packages/cli/lib/commands/validate-args.js
@@ -1,7 +1,7 @@
 const { error } = require('../util');
 
 function validateArgs(argv, options, command) {
-	let normalizedOptions = options.map(option => option.name.split(',')).flat(1);
+	let normalizedOptions = options.map(option => option.name.split(',')).reduce((acc, val) => acc.concat(val), []);
 	normalizedOptions = normalizedOptions.map(option => {
 		option = option.trim();
 		if (option.startsWith('--')) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: replace use of Array.prototype.flat() to ensure Node 10 compatibility


**Did you add tests for your changes?**

No

**Summary**


As stated in the Readme and in the `engine` property of the `package.json`, `preact-cli` 3.0.x should be compatible with Node 10. However, https://github.com/preactjs/preact-cli/pull/1467/files#diff-490a9490c1fcd253d926ffeaea6b185b15522512e53f6a9f36493122fcae9d2eR4 introduced the use of `Array.prototype.flat()` (in `validate-args.js` file) which is available on Node 11+.

To work around that and ensure Node 10 compatibility I replaced it with a good old `reduce` + `concat`.

---

Here is the current issue when running `npx preact-cli create preactjs-templates/default preact-latest` with Node 10:
```sh
✖ ERROR TypeError: options.map(...).flat is not a function
    at validateArgs (/Users/gmaisse/.npm/_npx/13643/lib/node_modules/preact-cli/lib/commands/validate-args.js:4:72)
    at command (/Users/gmaisse/.npm/_npx/13643/lib/node_modules/preact-cli/lib/commands/create.js:210:2)
    at Sade.parse (/Users/gmaisse/.npm/_npx/13643/lib/node_modules/preact-cli/node_modules/sade/lib/index.js:189:56)
    at Object.<anonymous> (/Users/gmaisse/.npm/_npx/13643/lib/node_modules/preact-cli/lib/index.js:83:6)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
```

**Does this PR introduce a breaking change?**

No, it fixes one.

