### PR TITLE
fix: Correcting create command finished instructions

### DIFF
--- a/.changeset/curvy-pugs-fail.md
+++ b/.changeset/curvy-pugs-fail.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Ensures the create command returns startup instructions to users

--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -410,20 +410,20 @@ async function command(repo, dest, argv) {
 
 	let pfx = isYarn ? 'yarn' : 'npm run';
 
-	return (
+	process.stdout.write(
 		trim(`
 		To get started, cd into the new directory:
-			${green('cd ' + dest)}
+		  ${green('cd ' + dest)}
 
 		To start a development live-reload server:
-			${green(pfx + ' dev')}
+		  ${green(pfx + ' dev')}
 
 		To create a production build (in ./build):
-			${green(pfx + ' build')}
+		  ${green(pfx + ' build')}
 
 		To start a production HTTP/2 server:
-			${green(pfx + ' serve')}
-	`) + '\n'
+		  ${green(pfx + ' serve')}
+	`) + '\n\n'
 	);
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

The CLI's `create` command is supposed to output some instructions to users upon completing. However, this is broken on the latest version, and looks to have been broken years ago. Was just hidden while everyone was still using `2.2.1` for their global installs. 

**Does this PR introduce a breaking change?**

No
