### PR TITLE
chore: Removes duplicated dev deps in CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,11 +45,8 @@
 	"bugs": "https://github.com/preactjs/preact-cli/issues",
 	"homepage": "https://github.com/preactjs/preact-cli",
 	"devDependencies": {
-		"eslint": "^7.12.1",
 		"html-looks-like": "^1.0.2",
 		"jest": "^26.0.1",
-		"lerna": "^3.16.4",
-		"lint-staged": "^10.5.0",
 		"mkdirp": "^1.0.3",
 		"ncp": "^2.0.0",
 		"node-sass": "^4.12.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Cleaning

**Did you add tests for your changes?**

No

**Summary**

Removes duplicated dev deps in CLI. CLI listed `eslint`, `lerna`, and `lint-staged` as dev deps when all 3 are already installed for the entire mono-repo. They don't serve a purpose.

**Does this PR introduce a breaking change?**

No
