### PR TITLE
Do not produce preRenderData when --no-prerender option is specified.

### DIFF
--- a/.changeset/tidy-starfishes-joke.md
+++ b/.changeset/tidy-starfishes-joke.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Do not produce preRenderData when --no-prerender option is specified.

--- a/packages/cli/lib/resources/body-end.ejs
+++ b/packages/cli/lib/resources/body-end.ejs
@@ -1,8 +1,8 @@
 <%= htmlWebpackPlugin.options.ssr() %>
 <% if (htmlWebpackPlugin.options.config.prerender === true) { %>
-<script type="__PREACT_CLI_DATA__">
-	<%= encodeURI(JSON.stringify(htmlWebpackPlugin.options.CLI_DATA)) %>
-</script>
+	<script type="__PREACT_CLI_DATA__">
+		<%= encodeURI(JSON.stringify(htmlWebpackPlugin.options.CLI_DATA)) %>
+	</script>
 <% } %>
 <% if (webpack.assets.filter(entry => entry.name.match(/bundle(\.\w{5})?.esm.js$/)).length > 0) { %>
 	<% /* Fix for safari < 11 nomodule bug. TODO: Do the following only for safari. */ %>

--- a/packages/cli/lib/resources/body-end.ejs
+++ b/packages/cli/lib/resources/body-end.ejs
@@ -1,7 +1,9 @@
 <%= htmlWebpackPlugin.options.ssr() %>
+<% if (htmlWebpackPlugin.options.config.prerender === true) { %>
 <script type="__PREACT_CLI_DATA__">
 	<%= encodeURI(JSON.stringify(htmlWebpackPlugin.options.CLI_DATA)) %>
 </script>
+<% } %>
 <% if (webpack.assets.filter(entry => entry.name.match(/bundle(\.\w{5})?.esm.js$/)).length > 0) { %>
 	<% /* Fix for safari < 11 nomodule bug. TODO: Do the following only for safari. */ %>
 	<script nomodule>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bug. Not harmful, but I think this is not intended behavior.

**Did you add tests for your changes?**
No.

**Summary**

`preact build --no-prerender` produces `<script type="__PREACT_CLI_DATA__">"preRenderData": { "url" : "/" }</script>` in
build/index.html.
But preRenderData is used in pre-rendered components, I expect that ` --no-prerender` needs to prevent preRenderData.

**Does this PR introduce a breaking change?**
Yes. 
I think existing programs do not rely on it.

**Other information**

Environment Info:
  System:
    OS: Linux 4.19 Ubuntu 20.04.1 LTS (Focal Fossa)
    CPU: (6) x64 AMD Ryzen 5 3500 6-Core Processor
  Binaries:
    Node: 14.15.4 - /usr/bin/node
    npm: 6.14.10 - /usr/bin/npm
  npmPackages:
    preact: ^10.3.2 => 10.5.10
    preact-cli: ^3.0.0 => 3.0.5
    preact-render-to-string: ^5.1.4 => 5.1.12
    preact-router: ^3.2.1 => 3.2.1
