### PR TITLE
fix: Bug where port is reassigned after given to devServer

### DIFF
--- a/.changeset/fuzzy-fans-sin.md
+++ b/.changeset/fuzzy-fans-sin.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fixes bug causing wrong port to be given to Webpack config

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -12,13 +12,14 @@ const transformConfig = require('./transform-config');
 const { error, isDir, warn } = require('../../util');
 
 async function devBuild(env) {
+	let userPort = parseInt(process.env.PORT || env.port, 10) || 8080;
+	env.port = await getPort({ port: userPort });
+
 	let config = await clientConfig(env);
 
 	await transformConfig(env, config);
 
-	let userPort =
-		parseInt(process.env.PORT || config.devServer.port, 10) || 8080;
-	let port = await getPort({ port: userPort });
+	let port = config.devServer.port;
 
 	let compiler = webpack(config);
 	return new Promise((res, rej) => {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -301,7 +301,7 @@ function isDev(config) {
 			publicPath: '/',
 			contentBase: src,
 			https: config.https,
-			port: process.env.PORT || config.port || 8080,
+			port: config.port,
 			host: process.env.HOST || config.host || '0.0.0.0',
 			disableHostCheck: true,
 			historyApiFallback: true,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

Closes #1526

The logic for seeing if a port was already in use came after the user-provided port (or the default, 8080) was assigned to the devServer and plugins. This meant that plugins like Prefresh were given say port 8080 to run on, but the server actually ended up listening on 45454 because 8080 was taken.

**Does this PR introduce a breaking change?**

No