### PR TITLE
fix: Correcting SW flag in dev

### DIFF
--- a/.changeset/twenty-months-smash.md
+++ b/.changeset/twenty-months-smash.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fixes SW flag in dev

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -290,8 +290,23 @@ function isDev(config) {
 			...(refresh ? [new RefreshPlugin()] : []),
 			new webpack.DefinePlugin({
 				'process.env.ADD_SW': config.sw,
+				'process.env.ES_BUILD': false,
 				'process.env.PRERENDER': config.prerender,
 			}),
+			...(config.sw
+				? [
+						new InjectManifest({
+							swSrc: join(src, 'sw.js'),
+							include: [
+								/200\.html$/,
+								/\.js$/,
+								/\.css$/,
+								/\.(png|jpg|svg|gif|webp)$/,
+							],
+							exclude: [/\.esm\.js$/],
+						}),
+				  ]
+				: []),
 		],
 
 		devServer: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix

**Did you add tests for your changes?**

No

**Summary**

Running `yarn dev --sw` would create an error that `process` was not defined. This is because there was no `DefinePlugin` entry for `process.env.ES_BUILD` on dev. This was found here https://github.com/preactjs/preact-cli/issues/1531#issuecomment-774520544

Upon adding that, the service worker would attempt to be installed but run into errors upon registering. The solution for that seems to be adding the `InjectManifest` as a plugin, though this isn't ideal and throws a workbox warning (https://github.com/GoogleChrome/workbox/issues/1790). Kinda seems like we just shouldn't support the non-debug SW during dev? 

Additionally, this still fails if ran with the `--esm` flag, as no `sw-esm.js` is generated in dev. But that's probably a separate issue. 

**Does this PR introduce a breaking change?**
No
