### PR TITLE
Specify sass-loader major version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The default templates comes with a `.css` file for each component. You can start
 
 #### [SASS]
 
-- `npm install --save-dev node-sass sass-loader` (inside your preact application folder)
+- `npm install --save-dev node-sass sass-loader@10` (inside your preact application folder)
 - start replacing `.css` files with `.scss` files
 
 #### [LESS]


### PR DESCRIPTION
v11 is not compatible with webpack v4

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Documentation change

**Did you add tests for your changes?**

**Summary**

sass-loader@11 is not compatible with webpack@4

**Does this PR introduce a breaking change?**

no

**Other information**

Please paste the results of `preact info` here.

```
$ LANGUAGE=C preact info

Command 'preact' not found, did you mean:

  command 'precat' from deb aspell (0.60.8-1build1)

Try: sudo apt install <deb name>
```