### PR TITLE
Introduce `devServerRunning` hook

### DIFF
--- a/packages/cli/lib/lib/webpack/hooks.js
+++ b/packages/cli/lib/lib/webpack/hooks.js
@@ -1,0 +1,5 @@
+const SyncHook = require('tapable').SyncHook;
+
+module.exports = {
+	devServerRunning: new SyncHook(),
+};

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -10,6 +10,7 @@ const clientConfig = require('./webpack-client-config');
 const serverConfig = require('./webpack-server-config');
 const transformConfig = require('./transform-config');
 const { error, isDir, warn } = require('../../util');
+const { devServerRunning } = require('./hooks');
 
 async function devBuild(env) {
 	let userPort = parseInt(process.env.PORT || env.port, 10) || 8080;
@@ -68,6 +69,7 @@ async function devBuild(env) {
 			}
 
 			showStats(stats, false);
+			devServerRunning.call();
 		});
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);

--- a/packages/cli/tests/hooks.test.js
+++ b/packages/cli/tests/hooks.test.js
@@ -1,0 +1,32 @@
+const { create, watch } = require('./lib/cli');
+const { hooks } = require('./lib/utils');
+
+describe('preact', () => {
+	let intervalId;
+
+	afterEach(() => {
+		clearInterval(intervalId);
+		intervalId = null;
+	});
+
+	it('should emit a devServerRunning event after the server starts', (done) => {
+		let hookCalled;
+		hooks.devServerRunning.tap('TestPlugin', () => {
+			hookCalled = true;
+		});
+
+		create('default').then((app) => {
+			watch(app, 8083).then((server) => {
+				// We need to wait not only for the server to start but also for the
+				// stats to be printed to stdout.
+				intervalId = setInterval(() => {
+					if (hookCalled) {
+						expect(hookCalled).toBe(true);
+						server.close();
+						done();
+					}
+				}, 1000);
+			});
+		});
+	});
+});

--- a/packages/cli/tests/lib/utils.js
+++ b/packages/cli/tests/lib/utils.js
@@ -5,6 +5,7 @@ const minimatch = require('minimatch');
 const pRetry = require('p-retry');
 const { promisify } = require('util');
 const glob = promisify(require('glob').glob);
+const hooks = require('../../lib/lib/webpack/hooks');
 
 const PER = 0.05; // % diff
 const LOG = !!process.env.WITH_LOG;
@@ -68,4 +69,5 @@ module.exports = {
 	sleep,
 	hasKey,
 	isWithin,
+	hooks,
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A build-related feature.

**Did you add tests for your changes?**

Yes.

**Summary**

Custom hooks are useful for other plugins to tap into certain points of the build process. In this case a `devServerRunning` hook is introduced which would allow a 3rd party plugin to, for example, display a QR code with the address the app is running on once the dev server started:

![](https://i.postimg.cc/xTTQ4yf0/Screenshot-2021-05-28-at-09-52-04.png)

Usage:
```ts
import hooks from 'preact-cli/lib/lib/webpack/hooks';

hooks.devServerRunning.tap('QrCodePlugin', () => {
  printQrCode();
});
```

**Does this PR introduce a breaking change?**

No.

**Other information**

```
Environment Info:
  System:
    OS: macOS 11.3.1
    CPU: (8) x64 Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
  Binaries:
    Node: 12.13.0 - /usr/local/bin/node
    Yarn: 1.22.10 - /usr/local/bin/yarn
    npm: 6.12.0 - /usr/local/bin/npm
  Browsers:
    Chrome: 91.0.4472.77
    Firefox: 88.0.1
    Safari: 14.1
  npmPackages:
    preact: ^10.3.1 => 10.5.13 
    preact-cli: ^3.0.0 => 3.0.5 
    preact-render-to-string: ^5.1.4 => 5.1.19 
    preact-router: ^3.2.1 => 3.2.1 
  npmGlobalPackages:
    preact-cli: 3.0.5
```
