### PR TITLE
fix: Un-breaks getLoadersByName helper

### DIFF
--- a/.changeset/mean-birds-return.md
+++ b/.changeset/mean-birds-return.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fixes breaking change to the getLoadersByName config helper

--- a/packages/cli/lib/lib/webpack/transform-config.js
+++ b/packages/cli/lib/lib/webpack/transform-config.js
@@ -235,7 +235,9 @@ class WebpackConfigHelpers {
 			)
 			.reduce((arr, loaders) => arr.concat(loaders), [])
 			.filter(
-				({ loader }) => loader === name || (loader && loader.loader === name)
+				({ loader }) =>
+					(typeof loader === 'string' && loader.includes(name)) ||
+					(typeof loader.loader === 'string' && loader.loader.includes(name))
 			);
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No

**Summary**

Fixes #1565 

#1418 broke the helper and it wasn't until after it was merged that I noticed this

**Does this PR introduce a breaking change?**

No