### PR TITLE
docs: Removing mention of Material template

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ Current available templates include:
 
 - [default] - Default template with all features.
 
-- [material] - material template using preact-material-components
-
 - [simple] - The simplest possible preact setup in a single file
 
 - [netlify] - Netlify CMS template using preact.


### PR DESCRIPTION
[It's been deprecated for over a year now](https://github.com/preactjs-templates/material/pull/30), don't want issues like https://github.com/preactjs-templates/material/issues/31 popping up if we can avoid them.