### PR TITLE
fix: Ensuring the sw flag is a boolean in watch mode

### DIFF
--- a/.changeset/tender-carrots-sniff.md
+++ b/.changeset/tender-carrots-sniff.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Ensuring the sw flag is a boolean in watch mode

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -2,9 +2,8 @@ const rimraf = require('rimraf');
 const { resolve } = require('path');
 const { promisify } = require('util');
 const runWebpack = require('../lib/webpack/run-webpack');
+const { toBool } = require('../util');
 const { validateArgs } = require('./validate-args');
-
-const toBool = val => val === void 0 || (val === 'false' ? false : val);
 
 const options = [
 	{

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -1,5 +1,5 @@
 const runWebpack = require('../lib/webpack/run-webpack');
-const { warn } = require('../util');
+const { toBool, warn } = require('../util');
 const { validateArgs } = require('./validate-args');
 
 const options = [
@@ -101,6 +101,7 @@ async function command(src, argv) {
 	}
 	argv.src = src || argv.src;
 	argv.production = false;
+	argv.sw = toBool(argv.sw);
 
 	if (argv.https || process.env.HTTPS) {
 		let { key, cert, cacert } = argv;

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -50,3 +50,7 @@ exports.normalizeTemplatesResponse = function (repos = []) {
 		description: repo.description || '',
 	}));
 };
+
+exports.toBool = function (val) {
+	return val === void 0 || (val === 'false' ? false : val);
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

Fixes #1594 

`preact watch --sw false` passed the value through as a string, rather than coercing to a boolean, which was an oversight.

**Does this PR introduce a breaking change?**

No
