### PR TITLE
Enable regenerator in legacy bundles

### DIFF
--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -10,8 +10,7 @@ module.exports = function (env, options = {}) {
 					modules: options.modules || false,
 					targets: {
 						browsers: options.browsers,
-					},
-					exclude: ['transform-regenerator'],
+					}
 				},
 			],
 		],


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Transpiles generators to regenerator in legacy bundles.

**Summary**

In 3.3.0, we stopped using `fast-async` to transpile async functions, however this meant they were transpiled to generators, which we don't transpile at all. The modern bundles should be unaffected by all of these changes, so let's enable regenerator to handle both async and generator functions in legacy bundles.

**Does this PR introduce a breaking change?**

No, it fixes an unintentionally-breaking change.
