### PR TITLE
Fix/sw src

### DIFF
--- a/.changeset/sixty-badgers-dance.md
+++ b/.changeset/sixty-badgers-dance.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Corrects error when `src/sw.js` does not exist and esm is disabled

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -66,7 +66,7 @@ async function clientConfig(env) {
 			  ]
 			: [
 					new InjectManifest({
-						swSrc: join(src, 'sw.js'),
+						swSrc: swPath,
 						include: [
 							/200\.html$/,
 							/\.js$/,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -127,7 +127,7 @@
     "stack-trace": "0.0.10",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.2.4",
+    "typescript": "~4.2.4",
     "update-notifier": "^5.1.0",
     "url-loader": "^4.1.1",
     "validate-npm-package-name": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14431,7 +14431,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.4:
+typescript@~4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix

**Did you add tests for your changes?**

No

**Summary**

With ESM disabled, `InjectManifest` used `join(src, sw.js)` to get the service worker path. If this did not exist (if the user [re]moved the file), the build would error out.

We already had a system set up to catch this and fall back to the one provided from `preact-cli`, just weren't using it on non-esm builds.

**Does this PR introduce a breaking change?**

No