### PR TITLE
fix: Test suite now uses config files again

### DIFF
--- a/packages/cli/lib/lib/webpack/transform-config.js
+++ b/packages/cli/lib/lib/webpack/transform-config.js
@@ -112,9 +112,7 @@ module.exports = async function (env, webpackConfig, isServer = false) {
 	// The line above results in an empty object w/ Jest,
 	// so we need to do the following in order to load it:
 	if (Object.keys(m).length === 0) {
-		try {
-			m = require(myConfig);
-		} catch {}
+		m = require(myConfig);
 	}
 
 	const transformers = parseConfig((m && m.default) || m);

--- a/packages/cli/lib/lib/webpack/transform-config.js
+++ b/packages/cli/lib/lib/webpack/transform-config.js
@@ -107,7 +107,15 @@ module.exports = async function (env, webpackConfig, isServer = false) {
 		);
 	}
 
-	const m = require('esm')(module)(myConfig);
+	let m = require('esm')(module)(myConfig);
+
+	// The line above results in an empty object w/ Jest,
+	// so we need to do the following in order to load it:
+	if (Object.keys(m).length === 0) {
+		try {
+			m = require(myConfig);
+		} catch {}
+	}
 
 	const transformers = parseConfig((m && m.default) || m);
 

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -176,14 +176,12 @@ describe('preact build', () => {
 	});
 
 	it('should use custom `preact.config.js`', async () => {
-		// app with custom template set via preact.config.js
+		// app with stable output name via preact.config.js
 		let dir = await subject('custom-webpack');
 		await build(dir);
 
-		let file = join(dir, 'build/index.html');
-		let html = await readFile(file, 'utf-8');
-
-		looksLike(html, images.webpack);
+		let file = join(dir, 'build/bundle.js');
+		expect(existsSync(file)).toBe(true);
 	});
 
 	it('should use template from the code folder', async () => {

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -191,21 +191,6 @@ exports.prerender.htmlSafe = `
 </body>
 `;
 
-exports.webpack = `
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>preact-webpack</title>
-	</head>
-	<body>
-		<h1>Guess what</h1>
-		<h2>This is an app with custom template</h2>
-		{{ ... }}
-	</body>
-</html>
-`;
-
 exports.template = `
 <!DOCTYPE html>
 <html lang="en">

--- a/packages/cli/tests/lib/output.js
+++ b/packages/cli/tests/lib/output.js
@@ -1,3 +1,4 @@
+const { existsSync, mkdirSync } = require('fs');
 const copy = require('ncp');
 const { resolve } = require('path');
 const { promisify } = require('util');
@@ -16,6 +17,9 @@ function tmpDir() {
 async function subject(name) {
 	let src = resolve(subjects, name);
 	let dest = tmpDir();
+	if (!existsSync(dest)) {
+		mkdirSync(dest, { recursive: true });
+	}
 	await promisify(copy)(src, dest);
 	return dest;
 }

--- a/packages/cli/tests/lib/output.js
+++ b/packages/cli/tests/lib/output.js
@@ -11,15 +11,15 @@ function tmpDir() {
 		.toString(36)
 		.replace(/[^a-z]+/g, '')
 		.substr(0, 12);
+	if (!existsSync(output)) {
+		mkdirSync(output, { recursive: true });
+	}
 	return resolve(output, str);
 }
 
 async function subject(name) {
 	let src = resolve(subjects, name);
 	let dest = tmpDir();
-	if (!existsSync(dest)) {
-		mkdirSync(dest, { recursive: true });
-	}
 	await promisify(copy)(src, dest);
 	return dest;
 }

--- a/packages/cli/tests/subjects/custom-webpack/preact.config.js
+++ b/packages/cli/tests/subjects/custom-webpack/preact.config.js
@@ -1,6 +1,3 @@
-const path = require('path');
-
-module.exports = function (config, env, helpers) {
-	if (env.ssr) return;
-	helpers.setHtmlTemplate(config, path.resolve(__dirname, './template.html'));
+module.exports = function (config) {
+	config.output.filename = '[name].js';
 };

--- a/packages/cli/tests/subjects/preload-chunks/preact.config.js
+++ b/packages/cli/tests/subjects/preload-chunks/preact.config.js
@@ -1,6 +1,0 @@
-module.exports = config => {
-	config.optimization.splitChunks = {
-		minSize: 0,
-	};
-	return config;
-};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test suite bug fixes & chores

**Did you add tests for your changes?**

Yes

**Summary**

Found in #1622, as it turns out, none of the config files (`preact.config.js`) have been loaded in our test suite in a fairly long time. [The `custom-webpack` subject calls a method that doesn't exist anymore](https://github.com/preactjs/preact-cli/blob/master/packages/cli/tests/subjects/custom-webpack/preact.config.js) and yet the test isn't throwing. The config files aren't even being used.

This PR corrects that, though the implementation is a bit rough? Basically if `esm` cannot provide the config we simply `require()` it.

The behavior is a bit odd though and I don't quite understand what the issue is. `export default function () {...}` worked with our previous set up, but `export default () => {...}`, `module.exports = function () {...}`, and `module.exports = () => {...}` did not. With this fix, the two `module.exports` formats work in the suite again, but `export default () => {...}` does not. Not sure why this might be.

**Does this PR introduce a breaking change?**

No