### PR TITLE
fix: TS warnings/errors hidden by console clearing

### DIFF
--- a/.changeset/few-carrots-laugh.md
+++ b/.changeset/few-carrots-laugh.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Ensures TS warnings/errors are not hidden by console clearing

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -33,6 +33,10 @@ async function devBuild(env) {
 			callback();
 		});
 
+		compiler.hooks.beforeCompile.tap('CliDevPlugin', () => {
+			if (env['clear']) clear(true);
+		});
+
 		compiler.hooks.done.tap('CliDevPlugin', stats => {
 			let devServer = config.devServer;
 			let protocol = process.env.HTTPS || devServer.https ? 'https' : 'http';
@@ -42,8 +46,6 @@ async function devBuild(env) {
 			}
 			let serverAddr = `${protocol}://${host}:${bold(env.port)}`;
 			let localIpAddr = `${protocol}://${ip.address()}:${bold(env.port)}`;
-
-			if (env['clear']) clear(true);
 
 			if (stats.hasErrors()) {
 				process.stdout.write(red('Build failed!\n\n'));


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

N/A

**Summary**

Closes https://github.com/preactjs-templates/typescript/issues/69

`ForkTsChecker` is ran async, and this usually (nearly always in my tests) results in errors/warnings being output before our own `done` hook. With the console clearing triggering in this hook, this meant errors/warnings from this plugin were hidden from users. They'd have to scroll (and know to scroll) in order to expose them often (again, we've set the reporting to async, so this output _could_ come after, but it seems pretty rare w/ the TS template).

By moving this to the `beforeCompile` hook, we can ensure this output is not covered up.

`beforeCompile` seemed like the best fit; it shows the initial webpack dev server info, progress plugin stuff, and even fixes the awkward issue of progress plugin and wds doubling up:

before
```
 Build  [                 ] 0% (0.0s) compilingℹ ｢wds｣: Project is running at http://0.0.0.0:3000/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from /home/ryun/Projects/foobar/src
ℹ ｢wds｣: 404s will fallback to /index.html
 Build  [====            ] 25% (0.7s) building
```

after
```
ℹ ｢wds｣: Project is running at http://0.0.0.0:3000/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from /home/ryun/Projects/foobar/src
ℹ ｢wds｣: 404s will fallback to /index.html
 Build  [====            ] 25% (0.7s) building
```

Anything before `done` will work just fine though, as that's when `ForkTsChecker` outputs. Not sure if there's a more idiomatic place for this.

**Does this PR introduce a breaking change?**

No