### PR TITLE
Ensure `types.d.ts` is bundled with `preact-cli`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,8 @@
   "files": [
     "sw",
     "lib",
-    "babel"
+    "babel",
+    "types.d.ts"
   ],
   "keywords": [
     "preact",


### PR DESCRIPTION
Update the `package.json` for the `cli` package to bundle the type declarations

**What kind of change does this PR introduce?**
Just a quick 1-line fix

**Did you add tests for your changes?**
Not sure how to test this

**Summary**

The current version on npm (v3.3.3) does not bundle the types.d.ts file. I was happy to see there was a `types.d.ts` file I could cop to my local environment, and thought it would be nice for it to be included in the package as well 😃.

**Does this PR introduce a breaking change?**
I don't think so