### PR TITLE
Specify `sass` package instead of `node-sass`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The default templates comes with a `.css` file for each component. You can start
 
 #### [SASS]
 
-- `npm install --save-dev node-sass sass-loader@10` (inside your preact application folder)
+- `npm install --save-dev sass sass-loader@10` (inside your preact application folder)
 - start replacing `.css` files with `.scss` files
 
 #### [LESS]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Documentation update. Fixes preactjs/preact-cli#1638

**Did you add tests for your changes?**

No.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Not as far as I know. I'm using the revision in my own project.

**Other information**

Please paste the results of `preact info` here.

```
$ preact info
-bash: preact: command not found
```
```
$ npx preact-cli info

Environment Info:
  System:
    OS: macOS 10.15.7
    CPU: (8) x64 Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
  Binaries:
    Node: 14.17.5 - ~/.nvm/versions/node/v14.17.5/bin/node
    npm: 7.20.6 - ~/.nvm/versions/node/v14.17.5/bin/npm
  Browsers:
    Chrome: 97.0.4692.71
    Firefox: 95.0.2
    Safari: 15.2
  npmPackages:
    preact: ^10.5.7 => 10.6.4 
    preact-cli: ^3.0.5 => 3.3.3 
    preact-render-to-string: ^5.1.12 => 5.1.19 
```