### PR TITLE
docs: Add mention of widget-typescript template

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ Current available templates include:
 
 - [default] - Default template with all features.
 
-- [simple] - The simplest possible preact setup in a single file
+- [simple] - The simplest possible preact setup in a single file.
 
 - [netlify] - Netlify CMS template using preact.
 
-- [typescript] - Default template implemented in TypeScript
+- [typescript] - Default template implemented in TypeScript.
 
 - [widget] - Template for a widget to be embedded in another website.
+
+- [widget-typescript] - Widget template implemented in TypeScript.
 
 > 💁 Tip: Any Github repo with a `'template'` folder can be used as a custom template: <br /> `preact create <username>/<repository> <project-name>`
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Documentation update.

**Did you add tests for your changes?**

No.

**Summary**

I noticed that there is a `widget-typescript` template among the official templates.

I don't know if it's ready for general use yet, but here's a PR to update the docs for whenever it is the right time.

I also added periods to the other items in the list for consistency.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
I don't think so.

**Other information**

Please paste the results of `preact info` here.

`preact info` returns an error.

Here's the output from `npx preact-cli info`

```
Environment Info:
  System:
    OS: macOS 10.15.7
    CPU: (8) x64 Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
  Binaries:
    Node: 14.17.5 - ~/.nvm/versions/node/v14.17.5/bin/node
    npm: 7.20.6 - ~/.nvm/versions/node/v14.17.5/bin/npm
  Browsers:
    Chrome: 97.0.4692.99
    Firefox: 96.0.1
    Safari: 15.2
```