### PR TITLE
Feat: Add 'PREACT_APP_' prefixed env vars automatically & pickup .env file

### DIFF
--- a/.changeset/stupid-suns-crash.md
+++ b/.changeset/stupid-suns-crash.md
@@ -1,0 +1,7 @@
+---
+'preact-cli': minor
+---
+
+Any environment variables prefixed with 'PREACT_APP_' will automatically be available for reference and use in your application without having to configure `DefinePlugin` any more. Furthermore, if a `.env` file exists in the root of your application, any variables it defines will automatically be available for use.
+
+Huge shout out to [robinvdvleuten](https://github.com/robinvdvleuten) who provided this functionality through the [`preact-cli-plugin-env-vars`](https://github.com/robinvdvleuten/preact-cli-plugin-env-vars) package in the past.

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ preact build --prerenderUrls src/prerender-urls.json
 If a static JSON file is too restrictive, you may want to provide a javascript file that exports your routes instead.
 Routes can be exported as a JSON string or an object and can optionally be returned from a function.
 
+> `prerender-urls.js`
+
 ```js
-// prerender-urls.js
 module.exports = [
 	{
 		url: '/',
@@ -311,19 +312,33 @@ The default templates comes with a `.css` file for each component. You can start
 
 ### Using Environment Variables
 
-You can reference and use environment variables in your `preact.config.js` by using `process.env`:
+You can reference and use any environment variable in your application that has been prefixed with `PREACT_APP_` automatically:
+
+> `src/index.js`
 
 ```js
-export default {
-	webpack(config, env, helpers, options) {
-		if (process.env.MY_VARIABLE) {
-			/** You can add a config here that will only used when your variable is truthy **/
-		}
-	},
-};
+console.log(process.env.PREACT_APP_MY_VARIABLE);
 ```
 
-If you'd like to use these variables in your application, you can use the [DefinePlugin] config from our recipes wiki.
+If your variable is not prefixed, you can still add it manually by using your `preact.config.js` (see [DefinePlugin] config in the recipes wiki).
+
+You can also set variables using a `.env` file in the root of your project:
+
+> `.env`
+
+```
+PREACT_APP_MY_VARIABLE="my-value"
+```
+
+You can also reference environment variables in your `preact.config.js`:
+
+```js
+export default (config, env, helpers, options) => {
+	if (process.env.MY_VARIABLE) {
+		/** You can add a config here that will only used when your variable is truthy **/
+	}
+};
+```
 
 ### Route-Based Code Splitting
 

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -92,6 +92,7 @@ async function command(src, argv) {
 	argv.production = toBool(argv.production);
 
 	let cwd = resolve(argv.cwd);
+	require('dotenv').config({ path: resolve(cwd, '.env') });
 	if (argv.clean === void 0) {
 		let dest = resolve(cwd, argv.dest);
 		await promisify(rimraf)(dest);

--- a/packages/cli/lib/commands/watch.js
+++ b/packages/cli/lib/commands/watch.js
@@ -2,6 +2,7 @@ const runWebpack = require('../lib/webpack/run-webpack');
 const { isPortFree, toBool, warn } = require('../util');
 const { validateArgs } = require('./validate-args');
 const getPort = require('get-port');
+const { resolve } = require('path');
 
 const options = [
 	{
@@ -104,6 +105,9 @@ async function command(src, argv) {
 	if (argv.sw) {
 		argv.sw = toBool(argv.sw);
 	}
+
+	let cwd = resolve(argv.cwd);
+	require('dotenv').config({ path: resolve(cwd, '.env') });
 
 	argv.port = await determinePort(argv.port);
 

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('dotenv').config();
 const envinfo = require('envinfo');
 const sade = require('sade');
 const notifier = require('update-notifier');

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -305,11 +305,21 @@ module.exports = function createBaseConfig(env) {
 
 		plugins: [
 			new webpack.NoEmitOnErrorsPlugin(),
-			new webpack.DefinePlugin({
-				'process.env.NODE_ENV': JSON.stringify(
-					isProd ? 'production' : 'development'
-				),
-			}),
+			new webpack.DefinePlugin(
+				Object.keys(process.env)
+					.filter(key => /^PREACT_APP_/.test(key))
+					.reduce(
+						(env, key) => {
+							env[`process.env.${key}`] = JSON.stringify(process.env[key]);
+							return env;
+						},
+						{
+							'process.env.NODE_ENV': JSON.stringify(
+								isProd ? 'production' : 'development'
+							),
+						}
+					)
+			),
 			new webpack.ProvidePlugin({
 				h: ['preact', 'h'],
 				Fragment: ['preact', 'Fragment'],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,6 +97,7 @@
     "critters-webpack-plugin": "^2.5.0",
     "cross-spawn-promise": "^0.10.1",
     "css-loader": "^5.2.4",
+    "dotenv": "^16.0.0",
     "ejs-loader": "^0.5.0",
     "envinfo": "^7.8.1",
     "esm": "^3.2.25",

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -254,4 +254,19 @@ describe('preact build', () => {
 			expect.stringMatching(getRegExpFromMarkup(images.pushManifest))
 		);
 	});
+
+	it('should use a custom `.env` with prefixed environment variables', async () => {
+		let dir = await subject('custom-dotenv');
+		await build(dir);
+
+		const bundleFile = (await readdir(`${dir}/build`)).find(file =>
+			/bundle\.\w{5}\.js$/.test(file)
+		);
+		const transpiledChunk = await readFile(
+			`${dir}/build/${bundleFile}`,
+			'utf8'
+		);
+		// "Hello World!" should replace 'process.env.PREACT_APP_MY_VARIABLE'
+		expect(transpiledChunk.includes('console.log("Hello World!")')).toBe(true);
+	});
 });

--- a/packages/cli/tests/subjects/custom-dotenv/.env
+++ b/packages/cli/tests/subjects/custom-dotenv/.env
@@ -1,0 +1,1 @@
+PREACT_APP_MY_VARIABLE="Hello World!"

--- a/packages/cli/tests/subjects/custom-dotenv/index.js
+++ b/packages/cli/tests/subjects/custom-dotenv/index.js
@@ -1,0 +1,1 @@
+console.log(process.env.PREACT_APP_MY_VARIABLE);

--- a/packages/cli/tests/subjects/custom-dotenv/package.json
+++ b/packages/cli/tests/subjects/custom-dotenv/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "preact-custom-dotenv"
+}

--- a/packages/cli/tests/watch.test.js
+++ b/packages/cli/tests/watch.test.js
@@ -34,6 +34,29 @@ describe('preact', () => {
 
 		server.close();
 	});
+
+	it.only('should use a custom `.env` with prefixed environment variables', async () => {
+		let app = await create('default');
+		server = await watch(app, 8084);
+
+		let page = await loadPage(chrome, 'http://127.0.0.1:8084/');
+
+		let header = resolve(app, './src/components/header/index.js');
+		let original = await readFile(header, 'utf8');
+		let update = original.replace(
+			'<h1>Preact App</h1>',
+			'<h1>{process.env.PREACT_APP_MY_VARIABLE}</h1>'
+		);
+		await writeFile(header, update);
+
+		// "Hello World!" should replace 'process.env.PREACT_APP_MY_VARIABLE'
+		await waitUntilExpression(
+			page,
+			`document.querySelector('header > h1').innerText === 'Hello World!'`
+		);
+
+		server.close();
+	});
 });
 
 describe('should determine the correct port', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,6 +5712,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Yes

**Summary**

This is something that's asked about fairly often and I figure it should become better supported for how low maintenance it is for us.

Any env vars prefixed with `PREACT_APP_` will now automatically be added to `DefinePlugin`. This matches what [CRA does](https://github.com/facebook/create-react-app/blob/bb64e31a81eb12d688c14713dce812143688750a/packages/react-scripts/config/env.js#L67-L69) and also (mostly) matches what [`preact-cli-plugin-env-vars` does](https://github.com/robinvdvleuten/preact-cli-plugin-env-vars/blob/a8436c8a3ed2da5e924af2dbf89330b906a35da1/index.js#L7-L8). This is still a fairly popular plugin, getting ~1/10 of the downloads per week that preact-cli itself is.

`.env` files in the user's project root are also now automatically consumed. Added `dotenv` for handling this.

**Does this PR introduce a breaking change?**

Shouldn't be, no.