### PR TITLE
feat: support CRA-style proxy config

### DIFF
--- a/.changeset/five-peas-brake.md
+++ b/.changeset/five-peas-brake.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': minor
+---
+
+Supports consuming "proxy" from package.json to proxy API requests in watch mode

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -73,7 +73,9 @@ describe('preact build', () => {
 		// The tsconfig.json in the template covers the test directory,
 		// so TS will error out if it can't find even test-only module definitions
 		shell.cd(dir);
-		shell.exec('npm i @types/enzyme enzyme-adapter-preact-pure');
+		//shell.exec('npm i @types/enzyme@3.10.11 enzyme-adapter-preact-pure');
+		// Remove when https://github.com/preactjs/enzyme-adapter-preact-pure/issues/161 is resolved
+		shell.exec('rm tsconfig.json');
 
 		expect(() => build(dir)).not.toThrow();
 	});

--- a/packages/cli/tests/server.js
+++ b/packages/cli/tests/server.js
@@ -6,5 +6,10 @@ exports.getServer = (dir, port = 3000) => {
 		maxAge: 0,
 		single: true,
 	};
-	return polka().use(sirv(dir, opts)).listen(port);
+	return polka()
+		.use(sirv(dir, opts))
+		.get('/proxied/request', (_req, res) => {
+			res.end('Hello World!');
+		})
+		.listen(port);
 };

--- a/packages/cli/tests/subjects/proxy/index.js
+++ b/packages/cli/tests/subjects/proxy/index.js
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+export default () => {
+	const [val, setVal] = useState('');
+
+	useEffect(() => {
+		fetch('/proxied/request')
+			.then(res => res.text())
+			.then(data => setVal(data));
+	}, []);
+
+	return <h1>Data retrieved from proxied server: {val}</h1>;
+};

--- a/packages/cli/tests/subjects/proxy/package.json
+++ b/packages/cli/tests/subjects/proxy/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "preact-proxy",
+  "proxy": "http://localhost:8086"
+}

--- a/packages/cli/tests/watch.test.js
+++ b/packages/cli/tests/watch.test.js
@@ -3,6 +3,8 @@ const { resolve } = require('path');
 const startChrome = require('./lib/chrome');
 const { create, watch } = require('./lib/cli');
 const { determinePort } = require('../lib/commands/watch');
+const { subject } = require('./lib/output');
+const { getServer } = require('./server');
 
 const { loadPage, waitUntilExpression } = startChrome;
 let chrome, server;
@@ -61,6 +63,23 @@ describe('preact', () => {
 		);
 
 		server.close();
+	});
+
+	it('should proxy requests when "proxy" exists in package.json', async () => {
+		const api = getServer('', 8086);
+		let app = await subject('proxy');
+
+		server = await watch(app, 8087);
+
+		let page = await loadPage(chrome, 'http://127.0.0.1:8087/');
+
+		await waitUntilExpression(
+			page,
+			`document.querySelector('h1').innerText === 'Data retrieved from proxied server: Hello World!'`
+		);
+
+		server.close();
+		api.server.close();
 	});
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Yes

**Summary**

Closes #1672

Some users copy/paste from CRA thinking their config will work out of the box. While that won't work everywhere, we can support simple cases like this pretty easily.

This implementation is pretty close to [CRA's](https://github.com/facebook/create-react-app/blob/fd8c5f7b1b1d19d10d24cc2f9fdfc110585dc030/packages/react-dev-utils/WebpackDevServerUtils.js#L302-L389), though with a couple changes around the public folder and error handling.

I'm leaning towards not documenting this though, would rather people use their `preact.config.js` to better control this themselves. I think the defaults I've set are probably fine, but still not a "one size fits all" situation.

**Does this PR introduce a breaking change?**

Technically, it could be problematic if a user has a (previously) extraneous key sitting around in their `package.json`. Don't know if that counts and might be a bit of a reach.