### PR TITLE
chore: Removes 'material' template from 'list' cmd output

### DIFF
--- a/.changeset/real-owls-bathe.md
+++ b/.changeset/real-owls-bathe.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Removes the archived & non-recommended 'material' template from 'preact list' output

--- a/packages/cli/lib/commands/list.js
+++ b/packages/cli/lib/commands/list.js
@@ -11,13 +11,14 @@ module.exports = async function () {
 		process.stdout.write('\n');
 		info('Available official templates: \n');
 
-		repos.forEach(repo => {
-			if (repo.name === 'material') return;
-			const description = repo.description ? ` - ${repo.description}` : '';
-			process.stdout.write(
-				`  ⭐️  ${bold(magenta(repo.name))}${description} \n`
-			);
-		});
+		repos
+			.filter(repo => !repo.archived)
+			.forEach(repo => {
+				const description = repo.description ? ` - ${repo.description}` : '';
+				process.stdout.write(
+					`  ⭐️  ${bold(magenta(repo.name))}${description} \n`
+				);
+			});
 
 		process.stdout.write('\n');
 	} catch (err) {

--- a/packages/cli/lib/commands/list.js
+++ b/packages/cli/lib/commands/list.js
@@ -11,7 +11,8 @@ module.exports = async function () {
 		process.stdout.write('\n');
 		info('Available official templates: \n');
 
-		repos.map(repo => {
+		repos.forEach(repo => {
+			if (repo.name === 'material') return;
 			const description = repo.description ? ` - ${repo.description}` : '';
 			process.stdout.write(
 				`  ⭐️  ${bold(magenta(repo.name))}${description} \n`


### PR DESCRIPTION
*What kind of change does this PR introduce?**

Chore

**Did you add tests for your changes?**

N/A

**Summary**

Removes the 'material' template from output of `preact list`. This template is archived and we've already removed it from the docs. 

**Does this PR introduce a breaking change?**

No. Users can still select it if they want, we just won't display/advertise it.