### PR TITLE
fix: HMR / `--refresh` flag

### DIFF
--- a/.changeset/young-bikes-compete.md
+++ b/.changeset/young-bikes-compete.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fixes HMR / `--refresh` flag in watch mode

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -332,6 +332,7 @@ function isDev(env) {
 
 		devServer: {
 			hot: true,
+			liveReload: !env.refresh,
 			compress: true,
 			devMiddleware: {
 				publicPath: '/',


### PR DESCRIPTION
Closes #1704 

CC @JoviDeCroock

Reading [Webpack's docs](https://webpack.js.org/configuration/dev-server/#devserverlivereload) it seems like this is a bug and unintended behavior, but upon explicitly disabling `liveReload`, HMR works beautifully. ~~Might be a docs issue for Prefresh at worst~~, but I'll open an issue w/ dev-server and see what they say.

Edit: Hmm, seems like we have something locally that's weird. Can't reproduce this outside of CLI.