### PR TITLE
fix: disable load manifest in dev

### DIFF
--- a/.changeset/tiny-books-flash.md
+++ b/.changeset/tiny-books-flash.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fix ensures that the load-manifest is only attempted to be built in prod. It serves no use in dev (as preloading is limited to prod) and can create a race condition when used alongside HMR.

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -1,4 +1,5 @@
-module.exports = (assets, namedChunkGroups) => {
+module.exports = (assets, namedChunkGroups, isProd) => {
+	if (!isProd) return {};
 	/**
 	 * This is a mapping of generic/pre-build filenames to their postbuild output
 	 *

--- a/packages/cli/lib/lib/webpack/push-manifest.js
+++ b/packages/cli/lib/lib/webpack/push-manifest.js
@@ -2,6 +2,9 @@ const webpack = require('webpack');
 const createLoadManifest = require('./create-load-manifest');
 
 module.exports = class PushManifestPlugin {
+	constructor(isProd) {
+		this.isProd = isProd;
+	}
 	apply(compiler) {
 		compiler.hooks.emit.tap(
 			{
@@ -11,7 +14,8 @@ module.exports = class PushManifestPlugin {
 			compilation => {
 				const manifest = createLoadManifest(
 					compilation.assets,
-					compilation.namedChunkGroups
+					compilation.namedChunkGroups,
+					this.isProd
 				);
 
 				let output = JSON.stringify(manifest);

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -89,7 +89,7 @@ module.exports = async function (config) {
 				if (assets['push-manifest.json']) {
 					return JSON.parse(assets['push-manifest.json'].source());
 				}
-				return createLoadManifest(assets, namedChunkGroups);
+				return createLoadManifest(assets, namedChunkGroups, config.isProd);
 			},
 			config,
 			url,

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -146,7 +146,7 @@ async function clientConfig(env) {
 				'process.env.ADD_SW': env.sw,
 				'process.env.PRERENDER': env.prerender,
 			}),
-			new PushManifestPlugin(),
+			new PushManifestPlugin(env.isProd),
 			...(await renderHTMLPlugin(env)),
 			...getBabelEsmPlugin(env),
 			copyPatterns.length !== 0 &&

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -331,7 +331,7 @@ function isDev(env) {
 		].filter(Boolean),
 
 		devServer: {
-			hot: true,
+			hot: env.refresh,
 			liveReload: !env.refresh,
 			compress: true,
 			devMiddleware: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfixes

**Did you add tests for your changes?**

Existing cover

**Summary**

Closes #1710

Looks like there's a race condition in the generation of the load manifest, where the asset manifest isn't guaranteed to exist yet. It's only been reproduced w/ HMR enabled, so that may be the key factor.

Regardless, this is only used to form preload tags, which is never done in dev. Therefore we can just skip the plugin outside of prod.

**Does this PR introduce a breaking change?**

I can't imagine anyone is consuming the load manifest themselves in dev, no. It's possible, but would be pretty weird and not really useful.