### PR TITLE
refactor: Separate internal concepts of config and env

### DIFF
--- a/.changeset/great-dryers-cross.md
+++ b/.changeset/great-dryers-cross.md
@@ -1,0 +1,9 @@
+---
+'preact-cli': major
+---
+
+Reduces the `env` parameter of `preact.config.js` to only contain 3 values: `isProd`, `isDev`, and `isServer`.
+
+Previously, `env` contained many semi-duplicated values (`production` and `isProd`, etc) as well as values that were unlikely to be of much use to many users (what flags were set, for instance). Because of this, the signal-to-noise ratio was rather low which we didn't like. As such, we reduced `env` down to the most basic environment info: what type of build is `preact-cli` doing and for which environement?
+
+If you customize your Webpack config using a `preact.config.js`, please be aware that you may need to update which values you consume from `env`.

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -79,7 +79,6 @@ async function command(src, argv) {
 	argv.src = src || argv.src;
 	// add `default:true`s, `--no-*` disables
 	argv.prerender = toBool(argv.prerender);
-	argv.production = toBool(argv.production);
 
 	let cwd = resolve(argv.cwd);
 
@@ -94,7 +93,7 @@ async function command(src, argv) {
 		await promisify(rimraf)(dest);
 	}
 
-	let stats = await runWebpack(argv, false);
+	let stats = await runWebpack(argv, true);
 
 	if (argv.json) {
 		await runWebpack.writeJsonStats(cwd, stats);

--- a/packages/cli/src/commands/watch.js
+++ b/packages/cli/src/commands/watch.js
@@ -96,7 +96,6 @@ async function command(src, argv) {
 		argv.refresh = argv.rhl;
 	}
 	argv.src = src || argv.src;
-	argv.production = false;
 	if (argv.sw) {
 		argv.sw = toBool(argv.sw);
 	}
@@ -120,7 +119,7 @@ async function command(src, argv) {
 		}
 	}
 
-	return runWebpack(argv, true);
+	return runWebpack(argv, false);
 }
 
 async function determinePort(port) {

--- a/packages/cli/src/lib/babel-config.js
+++ b/packages/cli/src/lib/babel-config.js
@@ -1,7 +1,10 @@
 const { tryResolveConfig } = require('../util');
 
-module.exports = function (env) {
-	const { babelConfig, cwd, isProd, refresh } = env;
+/**
+ * @param {boolean} isProd
+ */
+module.exports = function (config, isProd) {
+	const { babelConfig, cwd, refresh } = config;
 
 	const resolvedConfig =
 		babelConfig &&

--- a/packages/cli/src/lib/webpack/render-html-plugin.js
+++ b/packages/cli/src/lib/webpack/render-html-plugin.js
@@ -17,8 +17,12 @@ function read(path) {
 	return readFileSync(resolve(__dirname, path), 'utf-8');
 }
 
-module.exports = async function renderHTMLPlugin(config) {
+/**
+ * @param {import('../../../types').Env} env
+ */
+module.exports = async function renderHTMLPlugin(config, env) {
 	const { cwd, dest, src } = config;
+
 	const inProjectTemplatePath = resolve(src, 'template.html');
 	let template = defaultTemplate;
 	if (existsSync(inProjectTemplatePath)) {
@@ -89,6 +93,7 @@ module.exports = async function renderHTMLPlugin(config) {
 						inlineCss: config['inline-css'],
 						preload: config.preload,
 						config,
+						env,
 						preRenderData: values,
 						CLI_DATA: { preRenderData: { url, ...routeData } },
 						ssr: config.prerender ? prerender({ cwd, dest, src }, values) : '',

--- a/packages/cli/src/lib/webpack/run-webpack.js
+++ b/packages/cli/src/lib/webpack/run-webpack.js
@@ -10,26 +10,29 @@ const serverConfig = require('./webpack-server-config');
 const transformConfig = require('./transform-config');
 const { error, isDir, warn } = require('../../util');
 
-async function devBuild(env) {
-	let config = await clientConfig(env);
+/**
+ * @param {import('../../../types').Env} env
+ */
+async function devBuild(config, env) {
+	const webpackConfig = await clientConfig(config, env);
 
-	await transformConfig(env, config);
+	await transformConfig(webpackConfig, config, env);
 
-	let compiler = webpack(config);
+	let compiler = webpack(webpackConfig);
 	return new Promise((res, rej) => {
 		compiler.hooks.beforeCompile.tap('CliDevPlugin', () => {
 			if (env['clear']) clear(true);
 		});
 
 		compiler.hooks.done.tap('CliDevPlugin', stats => {
-			let devServer = config.devServer;
+			let devServer = webpackConfig.devServer;
 			let protocol = process.env.HTTPS || devServer.https ? 'https' : 'http';
 			let host = process.env.HOST || devServer.host || 'localhost';
 			if (host === '0.0.0.0' && process.platform === 'win32') {
 				host = 'localhost';
 			}
-			let serverAddr = `${protocol}://${host}:${bold(env.port)}`;
-			let localIpAddr = `${protocol}://${ip.address()}:${bold(env.port)}`;
+			let serverAddr = `${protocol}://${host}:${bold(config.port)}`;
+			let localIpAddr = `${protocol}://${ip.address()}:${bold(config.port)}`;
 
 			if (stats.hasErrors()) {
 				process.stdout.write(red('Build failed!\n\n'));
@@ -45,26 +48,28 @@ async function devBuild(env) {
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
 
-		let server = new DevServer(config.devServer, compiler);
+		let server = new DevServer(webpackConfig.devServer, compiler);
 		server.start();
 		res(server);
 	});
 }
 
-async function prodBuild(env) {
-	env = { ...env, isServer: false, dev: !env.production, ssr: false };
-	let config = await clientConfig(env);
-	await transformConfig(env, config);
+/**
+ * @param {import('../../../types').Env} env
+ */
+async function prodBuild(config, env) {
+	if (config.prerender) {
+		const serverEnv = { ...env, isServer: true };
 
-	if (env.prerender) {
-		const serverEnv = Object.assign({}, env, { isServer: true, ssr: true });
-		let ssrConfig = serverConfig(serverEnv);
-		await transformConfig(serverEnv, ssrConfig);
-		let serverCompiler = webpack(ssrConfig);
+		const serverWebpackConfig = serverConfig(config, serverEnv);
+		await transformConfig(serverWebpackConfig, config, serverEnv);
+		const serverCompiler = webpack(serverWebpackConfig);
 		await runCompiler(serverCompiler);
 	}
 
-	let clientCompiler = webpack(config);
+	const clientWebpackConfig = await clientConfig(config, env);
+	await transformConfig(clientWebpackConfig, config, env);
+	const clientCompiler = webpack(clientWebpackConfig);
 
 	try {
 		let stats = await runCompiler(clientCompiler);
@@ -220,20 +225,26 @@ function stripLoaderFromModuleNames(m) {
 	return m;
 }
 
-module.exports = function (env, watch = false) {
-	env.isProd = env.production; // shorthand
-	env.isWatch = !!watch; // use HMR?
-	env.cwd = resolve(env.cwd || process.cwd());
+/**
+ * @param {boolean} isProd
+ */
+module.exports = function (argv, isProd) {
+	const env = {
+		isProd,
+		isDev: !isProd,
+		isServer: false,
+	};
+	const config = argv;
+	config.cwd = resolve(argv.cwd || process.cwd());
 
-	// env.src='src' via `build` default
-	let src = resolve(env.cwd, env.src);
-	env.src = isDir(src) ? src : env.cwd;
+	// config.src='src' via `build` default
+	const src = resolve(config.cwd, argv.src);
+	config.src = isDir(src) ? src : config.cwd;
 
 	// attach sourcing helper
-	env.source = dir => resolve(env.src, dir);
+	config.source = dir => resolve(config.src, dir);
 
-	// determine build-type to run
-	return (watch ? devBuild : prodBuild)(env);
+	return (isProd ? prodBuild : devBuild)(config, env);
 };
 
 module.exports.writeJsonStats = writeJsonStats;

--- a/packages/cli/src/lib/webpack/webpack-base-config.js
+++ b/packages/cli/src/lib/webpack/webpack-base-config.js
@@ -59,14 +59,17 @@ function getSassConfiguration(...includePaths) {
 }
 
 /**
+ * @param {import('../../../types').Env} env
  * @returns {import('webpack').Configuration}
  */
-module.exports = function createBaseConfig(env) {
-	const { cwd, isProd, src, source } = env;
+module.exports = function createBaseConfig(config, env) {
+	const { cwd, src, source } = config;
+	const { isProd, isServer } = env;
+
 	// Apply base-level `env` values
-	env.dest = resolve(cwd, env.dest || 'build');
-	env.manifest = readJson(source('manifest.json')) || {};
-	env.pkg = readJson(resolve(cwd, 'package.json')) || {};
+	config.dest = resolve(cwd, config.dest || 'build');
+	config.manifest = readJson(source('manifest.json')) || {};
+	config.pkg = readJson(resolve(cwd, 'package.json')) || {};
 
 	// use browserslist config environment, config default, or default browsers
 	// default browsers are '> 0.5%, last 2 versions, Firefox ESR, not dead'
@@ -148,7 +151,7 @@ module.exports = function createBaseConfig(env) {
 					resolve: { mainFields: ['module', 'jsnext:main', 'browser', 'main'] },
 					type: 'javascript/auto',
 					loader: require.resolve('babel-loader'),
-					options: createBabelConfig(env),
+					options: createBabelConfig(config, isProd),
 				},
 				{
 					// LESS
@@ -291,7 +294,7 @@ module.exports = function createBaseConfig(env) {
 			new RemoveEmptyScriptsPlugin(),
 			new MiniCssExtractPlugin({
 				filename:
-					isProd && !env.isServer ? '[name].[contenthash:5].css' : '[name].css',
+					isProd && !isServer ? '[name].[contenthash:5].css' : '[name].css',
 				chunkFilename: isProd
 					? '[name].chunk.[contenthash:5].css'
 					: '[name].chunk.css',

--- a/packages/cli/src/lib/webpack/webpack-server-config.js
+++ b/packages/cli/src/lib/webpack/webpack-server-config.js
@@ -5,15 +5,15 @@ const baseConfig = require('./webpack-base-config');
 /**
  * @returns {import('webpack').Configuration}
  */
-function serverConfig(env) {
+function serverConfig(config) {
 	return {
 		entry: {
-			'ssr-bundle': env.source('index'),
+			'ssr-bundle': config.source('index'),
 		},
 		output: {
 			publicPath: '/',
 			filename: 'ssr-bundle.js',
-			path: resolve(env.dest, 'ssr-build'),
+			path: resolve(config.dest, 'ssr-build'),
 			libraryTarget: 'commonjs2',
 		},
 		externals: {
@@ -28,6 +28,9 @@ function serverConfig(env) {
 	};
 }
 
-module.exports = function createServerConfig(env) {
-	return merge(baseConfig(env), serverConfig(env));
+/**
+ * @param {import('../../../types').Env} env
+ */
+module.exports = function createServerConfig(config, env) {
+	return merge(baseConfig(config, env), serverConfig(config));
 };

--- a/packages/cli/tests/subjects/custom-template/template.html
+++ b/packages/cli/tests/subjects/custom-template/template.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title><% preact.title %></title>
-		<% if (cli.config.isProd) { %>
+		<% if (cli.env.isProd) { %>
 			<meta name="example-meta" content="Hello World">
 		<% } %>
 		<% preact.headEnd %>

--- a/packages/cli/types.d.ts
+++ b/packages/cli/types.d.ts
@@ -57,15 +57,9 @@ export type Config = {
  * to check for in your config
  */
 export type Env = {
-	src: string;
-	dest: string;
-	sw: boolean;
-	dev: boolean;
-	production: boolean;
 	isProd: boolean;
-	ssr: boolean;
-	prerender: boolean;
-	[key: string]: any;
+	isDev: boolean;
+	isServer: boolean;
 };
 
 export type Helpers = {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Existing cover

**Summary**

In CLI, we mix the concepts of 'configuration' and 'environment' quite heavily; this means mixing together properties like `isProd` and `pkg.dependencies`. Accordingly, in different parts of the source, we refer to this mega variable as `env` or `config`.

What this PR proposes is to separate these out: app configuration values are separate to environment values. 

This came about from a user messaging me about checking `env` in their `preact.config.js` and seeing all sorts of values that would never be of any use to them. See below for what `console.log(env)` results in.

<details>
  <summary>Full `env` object</summary>
  
```js
{
  _: [],
  prerender: false,
  sw: false,
  src: '/home/ryun/Projects/cli/src',
  dest: '/home/ryun/Projects/cli/build',
  cwd: '/home/ryun/Projects/cli',
  babelConfig: '.babelrc',
  json: undefined,
  template: undefined,
  preload: false,
  analyze: undefined,
  prerenderUrls: 'prerender-urls.json',
  brotli: false,
  'inline-css': true,
  config: 'preact.config.js',
  c: 'preact.config.js',
  production: true,
  isProd: true,
  isWatch: false,
  source: [Function (anonymous)],
  manifest: {
    name: 'foo',
    short_name: 'foo',
    start_url: '/',
    display: 'standalone',
    orientation: 'portrait',
    background_color: '#fff',
    theme_color: '#673ab8',
    icons: [ [Object], [Object] ]
  },
  pkg: {
    private: true,
    scripts: {
      build: 'preact build --no-prerender --no-sw',
      'serve:prod': 'sirv build --port 3000 --cors --single',
      'serve:dev': 'preact watch',
      lint: 'eslint src',
      test: 'jest'
    },
    devDependencies: {
      'preact-cli': 'file:.yalc/preact-cli',
      prettier: '^2.7.1',
      'prettier-config-rschristian': '^0.1.1',
      'sirv-cli': '1.0.3'
    },
    dependencies: {
      preact: '^10.3.2',
      'preact-iso': '^2.3.0',
      'preact-render-to-string': '^5.1.4',
      'preact-router': '^3.2.1'
    }
  },
  isServer: false,
  dev: false,
  ssr: false
}
```
</details>

While we could just limit what we return to users, this also creates potential issues in our source. It's difficult to know when and where we set what values as this is treated like a global, just a less convenient one. For example, I went on a bit of a hunt earlier in trying to find out where in the world we set `isServer`. Hint: it's absolutely no where near where we set `isProd` or the like.

Additionally, there's an issue of multiple semi-duplicated values: `production` and `isProd`, `ssr` and `isServer`. While some of these are set together as aliases, others are not, and there's always the potential issue of them not being in sync. We should cut these down into a consistent list of idiomatic conditions for both us and users to use.

**Does this PR introduce a breaking change?**

Yes, some values from `env` will be stripped. See changeset for better log.