### PR TITLE
fix: `push-manifest.json` CSS asset type

### DIFF
--- a/.changeset/shy-poets-sneeze.md
+++ b/.changeset/shy-poets-sneeze.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fix for CSS assets sometimes being mistakenly labeled as 'scripts' in the push-manifest.

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -41,7 +41,7 @@ module.exports = (assets, namedChunkGroups, isProd) => {
 			const routeJs = assets[`${route}.js`];
 
 			routeManifest[routeJs] = { type: 'script', weight: 0.9 };
-			if (routeCss) routeManifest[routeCss] = { type: 'script', weight: 0.9 };
+			if (routeCss) routeManifest[routeCss] = { type: 'style', weight: 0.9 };
 
 			const path = route.replace(/^route-/, '/').replace(/^\/home/, '/');
 

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -52,6 +52,7 @@ module.exports = (assets, namedChunkGroups, isProd) => {
 					asyncFiles.chunks.forEach(asset => {
 						asset.files = asset.files || [];
 						asset.files.forEach(file => {
+							if (routeManifest[file]) return;
 							if (/\.css$/.test(file)) {
 								routeManifest[file] = { type: 'style', weight: 0.9 };
 							} else if (/\.js$/.test(file)) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No

**Summary**

Bug introduced by typo in #1680

I believe this is more of a theoretical bug than a real issue at this time. Our test suite ensures everything is working as intended in the basic situations at least:

https://github.com/preactjs/preact-cli/blob/6aba5d8e4c165c81f258ca9f367fea6c9a08cf17/packages/cli/tests/images/build.js#L219-L237

In order to handle async chunks generated by Webpack, we loop through the chunks and assign types accordingly. We don't skip the main route chunks while doing so despite them already being set (~~which maybe we should correct but not really important either way~~ did it), so this corrected for the wrong type being set:

https://github.com/preactjs/preact-cli/blob/6aba5d8e4c165c81f258ca9f367fea6c9a08cf17/packages/cli/lib/lib/webpack/create-load-manifest.js#L52-L56

**Does this PR introduce a breaking change?**

No
