### PR TITLE
test: Add CLI tests for all subcommands & most of their flags

### DIFF
--- a/packages/cli/global.d.ts
+++ b/packages/cli/global.d.ts
@@ -1,11 +1,17 @@
-declare global {
-	const __webpack_public_path__: string;
-	namespace jest {
-		interface Matchers<R> {
-			toBeCloseInSize(receivedSize: number, expectedSize: number): R;
-			toFindMatchingKey(receivedKey: string): R;
-		}
+declare const __webpack_public_path__: string;
+
+declare namespace jest {
+	interface Matchers<R> {
+		toBeCloseInSize(receivedSize: number, expectedSize: number): R;
+		toFindMatchingKey(receivedKey: string): R;
 	}
 }
 
-export {};
+// Modified from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/shelljs/index.d.ts
+declare module 'shelljs' {
+	const shell: {
+		cd: (string) => void;
+		exec: (string) => { stdout: string; stderr: string; code: number };
+	};
+	export = shell;
+}

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -83,13 +83,6 @@ describe('preact build', () => {
 	it('builds the `typescript` template', async () => {
 		let dir = await create('typescript');
 
-		// The tsconfig.json in the template covers the test directory,
-		// so TS will error out if it can't find even test-only module definitions
-		shell.cd(dir);
-		//shell.exec('npm i @types/enzyme@3.10.11 enzyme-adapter-preact-pure');
-		// Remove when https://github.com/preactjs/enzyme-adapter-preact-pure/issues/161 is resolved
-		shell.exec('rm tsconfig.json');
-
 		await expect(build(dir)).resolves.not.toThrow();
 	});
 

--- a/packages/cli/tests/create.test.js
+++ b/packages/cli/tests/create.test.js
@@ -1,11 +1,12 @@
-const { readFile } = require('fs').promises;
-const { relative, resolve } = require('path');
+const { access, readFile } = require('fs').promises;
+const { join, relative } = require('path');
 const { create } = require('./lib/cli');
 const { expand } = require('./lib/utils');
 const snapshots = require('./images/create');
+const shell = require('shelljs');
 
 describe('preact create', () => {
-	it(`scaffolds the 'default' official template`, async () => {
+	it('scaffolds the `default` official template', async () => {
 		let dir = await create('default');
 
 		let output = await expand(dir).then(arr => {
@@ -15,29 +16,44 @@ describe('preact create', () => {
 		expect(output.sort()).toEqual(snapshots.default);
 	});
 
-	it(`should use template.html from the github repo`, async () => {
+	it('should use template.html from the github repo', async () => {
 		let dir = await create('netlify');
-
-		const templateFilePath = resolve(__dirname, dir, 'src', 'template.html');
-		const template = await readFile(templateFilePath, 'utf8');
-
+		const template = await readFile(join(dir, 'src/template.html'), 'utf8');
 		expect(template.includes('twitter:card')).toEqual(true);
 	});
 
-	it(`should have 'apple-touch-icon' meta tag`, async () => {
-		let dir = await create('simple');
+	describe('CLI Options', () => {
+		it('--name', async () => {
+			let dir = await create('simple', { name: 'renamed' });
+			const packageJson = await readFile(join(dir, 'package.json'), 'utf8');
 
-		const templateFilePath = resolve(__dirname, dir, 'src', 'template.html');
-		const template = await readFile(templateFilePath, 'utf8');
+			expect(JSON.parse(packageJson).name).toBe('renamed');
 
-		expect(template.includes('apple-touch-icon')).toEqual(true);
-	});
+			// @ts-ignore
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+			await create('simple', { name: '*()@!#!$-Invalid-Name' });
+			expect(mockExit).toHaveBeenCalledWith(1);
+			mockExit.mockRestore();
+		});
 
-	it('should fail given an invalid name', async () => {
-		// @ts-ignore
-		const exit = jest.spyOn(process, 'exit').mockImplementation(() => {});
-		await create('simple', '*()@!#!$-Invalid-Name');
+		it('--git', async () => {
+			let dir = await create('simple', { git: true });
+			expect(await access(join(dir, '.git'))).toBeUndefined();
 
-		expect(exit).toHaveBeenCalledWith(1);
+			dir = await create('simple', { git: false });
+			await expect(access(join(dir, '.git'))).rejects.toThrow(
+				'no such file or directory'
+			);
+		});
+
+		it('--invalid-arg', () => {
+			const { code, stderr } = shell.exec(
+				`node ${join(__dirname, '../src/index.js')} create --invalid-arg`
+			);
+			expect(stderr).toMatch(
+				"Invalid argument '--invalid-arg' passed to create."
+			);
+			expect(code).toBe(1);
+		});
 	});
 });

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -200,7 +200,7 @@ exports.template = `
 	<head>
 		<meta charset="utf-8">
 		<title>preact-custom-template</title>
-		<meta name="example-meta" content="Hello World">
+		<meta name="example-meta" content="Hello Prod">
 		<link rel="manifest" href="/manifest.json">
 	</head>
 	<body>

--- a/packages/cli/tests/info.test.js
+++ b/packages/cli/tests/info.test.js
@@ -1,0 +1,24 @@
+const { join } = require('path');
+const shell = require('shelljs');
+const { subject } = require('./lib/output');
+
+describe('preact info', () => {
+	it('--src', async () => {
+		let dir = await subject('minimal');
+		// env-info does not pick up on symlinks, so we need to install deps
+		shell.exec(`npm --prefix ${dir} i preact preact-render-to-string`);
+
+		const _cwd = process.cwd();
+
+		shell.cd(dir);
+		const { code, stdout } = shell.exec(
+			`node ${join(__dirname, '../src/index.js')} info`
+		);
+		['OS', 'Node', 'preact', 'preact-render-to-string'].forEach(label => {
+			expect(stdout).toMatch(`${label}:`);
+		});
+		expect(code).toBe(0);
+
+		shell.cd(_cwd);
+	});
+});

--- a/packages/cli/tests/lib/utils.js
+++ b/packages/cli/tests/lib/utils.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-const { relative, resolve } = require('path');
-const { stat, readFile, writeFile } = require('fs').promises;
+const { join, relative, resolve } = require('path');
+const { stat, symlink, readFile, writeFile } = require('fs').promises;
 const pRetry = require('p-retry');
 const { promisify } = require('util');
 const glob = promisify(require('glob').glob);
@@ -61,6 +61,16 @@ function waitUntil(action, errorMessage) {
 
 const sleep = promisify(setTimeout);
 
+async function linkPackage(name, cwd) {
+	const root = join(__dirname, '../../../..');
+	try {
+		await symlink(
+			join(root, 'node_modules', name),
+			join(cwd, 'node_modules', name)
+		);
+	} catch {}
+}
+
 expect.extend({
 	toFindMatchingKey(key, matchingKey) {
 		if (matchingKey) {
@@ -109,4 +119,5 @@ module.exports = {
 	log,
 	waitUntil,
 	sleep,
+	linkPackage,
 };

--- a/packages/cli/tests/list.test.js
+++ b/packages/cli/tests/list.test.js
@@ -1,0 +1,21 @@
+const { join } = require('path');
+const shell = require('shelljs');
+
+describe('preact list', () => {
+	it('lists the official templates', () => {
+		const { code, stdout } = shell.exec(
+			`node ${join(__dirname, '../src/index.js')} list`
+		);
+		[
+			'default',
+			'netlify',
+			'simple',
+			'typescript',
+			'widget',
+			'widget-typescript',
+		].forEach(repoName => {
+			expect(stdout).toMatch(new RegExp(`${repoName}.* -`, 'g'));
+		});
+		expect(code).toBe(0);
+	});
+});

--- a/packages/cli/tests/subjects/custom-template/template.html
+++ b/packages/cli/tests/subjects/custom-template/template.html
@@ -4,7 +4,9 @@
 		<meta charset="utf-8">
 		<title><% preact.title %></title>
 		<% if (htmlWebpackPlugin.options.config.isProd) { %>
-			<meta name="example-meta" content="Hello World">
+			<meta name="example-meta" content="Hello Prod">
+		<% } else { %>
+			<meta name="example-meta" content="Hello Dev">
 		<% } %>
 		<% preact.headEnd %>
 	</head>

--- a/packages/cli/tests/subjects/custom-webpack/index.js
+++ b/packages/cli/tests/subjects/custom-webpack/index.js
@@ -1,3 +1,3 @@
 import { h } from 'preact';
 
-export default () => <h2>This is an app with custom template</h2>;
+export default () => <h2>This is an app with custom webpack config</h2>;

--- a/packages/cli/tests/subjects/custom-webpack/preact.config.js
+++ b/packages/cli/tests/subjects/custom-webpack/preact.config.js
@@ -1,3 +1,7 @@
-module.exports = function (config) {
-	config.output.filename = '[name].js';
+module.exports = function (config, env) {
+	if (env.isProd) {
+		config.output.filename = '[name].js';
+	} else {
+		config.output.filename = 'renamed-bundle.js';
+	}
 };

--- a/packages/cli/tests/watch.test.js
+++ b/packages/cli/tests/watch.test.js
@@ -272,17 +272,5 @@ describe('should determine the correct port', () => {
 		expect(ports[1]).not.toBe(4004);
 		expect(ports[1]).toBeGreaterThanOrEqual(1024);
 		expect(ports[1]).toBeLessThanOrEqual(65535);
-
-		// This is pretty awful, but would be the way to do it. get-port locks the port for ~30 seconds,
-		// so if we want to test any behavior with our default (8080) twice, we'd have to wait :/
-		//
-		//await sleep(35000);
-
-		//process.env.PORT = undefined;
-		//const ports = await Promise.all([determinePort(), determinePort()]);
-		//expect(ports[0]).toBe(8080);
-		//expect(ports[1]).not.toBe(8080);
-		//expect(ports[1]).toBeGreaterThanOrEqual(1024);
-		//expect(ports[1]).toBeLessThanOrEqual(65535);
 	});
 });

--- a/packages/cli/tests/watch.test.js
+++ b/packages/cli/tests/watch.test.js
@@ -1,10 +1,12 @@
-const { readFile, writeFile } = require('fs').promises;
-const { resolve } = require('path');
+const { mkdir, readFile, rename, writeFile } = require('fs').promises;
+const { join, resolve } = require('path');
 const startChrome = require('./lib/chrome');
 const { create, watch } = require('./lib/cli');
 const { determinePort } = require('../src/commands/watch');
 const { subject } = require('./lib/output');
 const { getServer } = require('./server');
+const shell = require('shelljs');
+const fetch = require('isomorphic-unfetch');
 
 const { loadPage, waitUntilExpression } = startChrome;
 let chrome, server;
@@ -20,7 +22,7 @@ describe('preact', () => {
 
 	it('should create development server with hot reloading.', async () => {
 		let app = await create('default');
-		server = await watch(app, 8083);
+		server = await watch(app, { port: 8083 });
 
 		let page = await loadPage(chrome, 'http://127.0.0.1:8083/');
 
@@ -52,7 +54,7 @@ describe('preact', () => {
 			'PREACT_APP_MY_VARIABLE="Hello World!"'
 		);
 
-		server = await watch(app, 8085);
+		server = await watch(app, { port: 8085 });
 
 		let page = await loadPage(chrome, 'http://127.0.0.1:8085/');
 
@@ -69,7 +71,7 @@ describe('preact', () => {
 		const api = getServer('', 8086);
 		let app = await subject('proxy');
 
-		server = await watch(app, 8087);
+		server = await watch(app, { port: 8087 });
 
 		let page = await loadPage(chrome, 'http://127.0.0.1:8087/');
 
@@ -80,6 +82,157 @@ describe('preact', () => {
 
 		server.close();
 		api.server.close();
+	});
+
+	describe('CLI Options', () => {
+		it('--src', async () => {
+			let app = await subject('minimal');
+
+			await mkdir(join(app, 'renamed-src'));
+			await rename(join(app, 'index.js'), join(app, 'renamed-src/index.js'));
+			await rename(join(app, 'style.css'), join(app, 'renamed-src/style.css'));
+
+			server = await watch(app, { port: 8088, src: 'renamed-src' });
+
+			let page = await loadPage(chrome, 'http://127.0.0.1:8088/');
+
+			await waitUntilExpression(
+				page,
+				`document.querySelector('h1').innerText === 'Minimal App'`
+			);
+
+			server.close();
+		});
+
+		it('--esm', async () => {
+			let app = await subject('minimal');
+
+			server = await watch(app, { port: 8089, esm: true });
+			let bundle = await fetch('http://127.0.0.1:8089/bundle.esm.js').then(
+				res => res.text()
+			);
+			expect(bundle).toMatch('Minimal App');
+			server.close();
+		});
+
+		it('--sw', async () => {
+			let app = await subject('minimal');
+
+			// The `waitUntil` in these tests ensures the SW is installed before our checks
+			server = await watch(app, { port: 8090 });
+			let page = await chrome.newPage();
+			await page.goto('http://127.0.0.1:8090/', { waitUntil: 'networkidle0' });
+			expect(
+				await page.evaluate(async () => {
+					return await navigator.serviceWorker
+						.getRegistrations()
+						.then(registrations =>
+							registrations[0].active.scriptURL.endsWith('/sw-debug.js')
+						);
+				})
+			).toBe(true);
+			server.close();
+
+			server = await watch(app, { port: 8091, sw: true });
+			page = await chrome.newPage();
+			await page.goto('http://127.0.0.1:8091/', { waitUntil: 'networkidle0' });
+			expect(
+				await page.evaluate(async () => {
+					return await navigator.serviceWorker
+						.getRegistrations()
+						.then(registrations =>
+							registrations[0].active.scriptURL.endsWith('/sw.js')
+						);
+				})
+			).toBe(true);
+			server.close();
+
+			server = await watch(app, { port: 8092, sw: false });
+			page = await chrome.newPage();
+			await page.goto('http://127.0.0.1:8092/', { waitUntil: 'networkidle0' });
+			expect(
+				await page.evaluate(async () => {
+					return await navigator.serviceWorker
+						.getRegistrations()
+						.then(registrations => registrations);
+				})
+			).toHaveLength(0);
+			server.close();
+		});
+
+		it('--babelConfig', async () => {
+			let app = await subject('custom-babelrc');
+
+			server = await watch(app, { port: 8093 });
+			let bundle = await fetch('http://127.0.0.1:8093/bundle.js').then(res =>
+				res.text()
+			);
+			expect(/=>\s?setTimeout/.test(bundle)).toBe(true);
+			server.close();
+
+			await rename(join(app, '.babelrc'), join(app, 'babel.config.json'));
+			server = await watch(app, {
+				port: 8094,
+				babelConfig: 'babel.config.json',
+			});
+			bundle = await fetch('http://127.0.0.1:8094/bundle.js').then(res =>
+				res.text()
+			);
+			expect(/=>\s?setTimeout/.test(bundle)).toBe(true);
+
+			server.close();
+		});
+
+		it('--template', async () => {
+			let app = await subject('custom-template');
+
+			await rename(
+				join(app, 'template.html'),
+				join(app, 'renamed-template.html')
+			);
+
+			server = await watch(app, {
+				port: 8095,
+				template: 'renamed-template.html',
+			});
+			const html = await fetch('http://127.0.0.1:8095/').then(res =>
+				res.text()
+			);
+			expect(html).toMatch('<meta name="example-meta" content="Hello Dev">');
+			server.close();
+		});
+
+		it('--config', async () => {
+			let app = await subject('custom-webpack');
+
+			server = await watch(app, { port: 8096, config: 'preact.config.js' });
+			let bundle = await fetch('http://127.0.0.1:8096/renamed-bundle.js').then(
+				res => res.text()
+			);
+			expect(bundle).toMatch('This is an app with custom webpack config');
+			server.close();
+
+			await rename(
+				join(app, 'preact.config.js'),
+				join(app, 'renamed-config.js')
+			);
+			server = await watch(app, { port: 8097, config: 'renamed-config.js' });
+			bundle = await fetch('http://127.0.0.1:8097/renamed-bundle.js').then(
+				res => res.text()
+			);
+			expect(bundle).toMatch('This is an app with custom webpack config');
+			server.close();
+		});
+
+		it('--invalid-arg', async () => {
+			const { code, stderr } = shell.exec(
+				`node ${join(__dirname, '../src/index.js')} watch --invalid-arg`
+			);
+			expect(stderr).toMatch(
+				"Invalid argument '--invalid-arg' passed to watch."
+			);
+			expect(code).toBe(1);
+		});
 	});
 });
 
@@ -114,11 +267,11 @@ describe('should determine the correct port', () => {
 
 	it('should fallback to random if $PORT or 8080 are taken and --port is not specified', async () => {
 		process.env.PORT = '4004';
-		await Promise.all([determinePort(), determinePort()]).then(values => {
-			expect(values[0]).toBe(4004);
-			expect(values[1]).toBeGreaterThanOrEqual(1024);
-			expect(values[1]).toBeLessThanOrEqual(65535);
-		});
+		const ports = await Promise.all([determinePort(), determinePort()]);
+		expect(ports[0]).toBe(4004);
+		expect(ports[1]).not.toBe(4004);
+		expect(ports[1]).toBeGreaterThanOrEqual(1024);
+		expect(ports[1]).toBeLessThanOrEqual(65535);
 
 		// This is pretty awful, but would be the way to do it. get-port locks the port for ~30 seconds,
 		// so if we want to test any behavior with our default (8080) twice, we'd have to wait :/
@@ -126,11 +279,10 @@ describe('should determine the correct port', () => {
 		//await sleep(35000);
 
 		//process.env.PORT = undefined;
-		//await Promise.all([determinePort(), determinePort()]).then(values => {
-		//	console.log(values);
-		//	expect(values[0]).toBe(8080);
-		//	expect(values[1]).toBeGreaterThanOrEqual(1024);
-		//	expect(values[1]).toBeLessThanOrEqual(65535);
-		//});
+		//const ports = await Promise.all([determinePort(), determinePort()]);
+		//expect(ports[0]).toBe(8080);
+		//expect(ports[1]).not.toBe(8080);
+		//expect(ports[1]).toBeGreaterThanOrEqual(1024);
+		//expect(ports[1]).toBeLessThanOrEqual(65535);
 	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

tests

**Did you add tests for your changes?**

Yes

**Summary**

Originally part of #1699 but extracted out to simplify the diff.

Just adds a whole bunch of tests and fixes some blind spots. Adds new test suites for `info` and `list` commands as well as adds tests for nearly every CLI flag. I did skip some due to being slow (like `--install` for `create`) or already being covered well enough (`--cwd` for both `build` & `create` basically runs our test suite).

**Does this PR introduce a breaking change?**

No
