### PR TITLE
feat: Improved errors and warnings

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -2,6 +2,7 @@
 const envinfo = require('envinfo');
 const sade = require('sade');
 const notifier = require('update-notifier');
+const { green } = require('kleur');
 const { error } = require('./util');
 const pkg = require('../package.json');
 
@@ -120,10 +121,14 @@ function exec(cmd) {
 }
 
 /**
- * @param {Error} err
+ * @param {Error | import('webpack').StatsError} err
  */
 async function catchExceptions(err) {
-	error(err.stack || err.message);
+	// Webpack Stats Error
+	if ('moduleName' in err && 'loc' in err) {
+		error(`${err.moduleName} ${green(err.loc)}\n${err.message}\n\n`);
+	}
+	error(err.stack || err.message || err);
 }
 
 process.on('unhandledRejection', catchExceptions);

--- a/packages/cli/src/lib/webpack/prerender.js
+++ b/packages/cli/src/lib/webpack/prerender.js
@@ -5,7 +5,7 @@ const stackTrace = require('stack-trace');
 const URL = require('url');
 const { SourceMapConsumer } = require('source-map');
 
-module.exports = function (env, params) {
+module.exports = async function (env, params) {
 	params = params || {};
 
 	let entry = resolve(env.dest, './ssr-build/ssr-bundle.js');
@@ -37,7 +37,7 @@ module.exports = function (env, params) {
 			throw err;
 		}
 
-		handlePrerenderError(err, env, stack, entry);
+		await handlePrerenderError(err, env, stack, entry);
 	}
 };
 

--- a/packages/cli/src/lib/webpack/render-html-plugin.js
+++ b/packages/cli/src/lib/webpack/render-html-plugin.js
@@ -76,7 +76,7 @@ module.exports = async function renderHTMLPlugin(config, env) {
 			title,
 			filename,
 			template: `!!${require.resolve('ejs-loader')}?esModule=false!${template}`,
-			templateParameters: (compilation, assets, assetTags, options) => {
+			templateParameters: async (compilation, assets, assetTags, options) => {
 				let entrypoints = {};
 				compilation.entrypoints.forEach((entrypoint, name) => {
 					let entryFiles = entrypoint.getFiles();
@@ -96,7 +96,9 @@ module.exports = async function renderHTMLPlugin(config, env) {
 						env,
 						preRenderData: values,
 						CLI_DATA: { preRenderData: { url, ...routeData } },
-						ssr: config.prerender ? prerender({ cwd, dest, src }, values) : '',
+						ssr: config.prerender
+							? await prerender({ cwd, dest, src }, values)
+							: '',
 						entrypoints,
 					},
 					htmlWebpackPlugin: {

--- a/packages/cli/src/lib/webpack/run-webpack.js
+++ b/packages/cli/src/lib/webpack/run-webpack.js
@@ -2,12 +2,12 @@ const ip = require('ip');
 const webpack = require('webpack');
 const { resolve } = require('path');
 const clear = require('console-clear');
-const { bold, red, green, magenta } = require('kleur');
+const { bold, green, magenta } = require('kleur');
 const DevServer = require('webpack-dev-server');
 const clientConfig = require('./webpack-client-config');
 const serverConfig = require('./webpack-server-config');
 const transformConfig = require('./transform-config');
-const { error, isDir, warn } = require('../../util');
+const { isDir, warn } = require('../../util');
 
 /**
  * @param {import('../../../types').Env} env
@@ -33,16 +33,12 @@ async function devBuild(config, env) {
 			let serverAddr = `${protocol}://${host}:${bold(config.port)}`;
 			let localIpAddr = `${protocol}://${ip.address()}:${bold(config.port)}`;
 
-			if (stats.hasErrors()) {
-				process.stdout.write(red('Build failed!\n\n'));
-			} else {
+			if (!stats.hasErrors()) {
 				process.stdout.write(green('Compiled successfully!\n\n'));
 				process.stdout.write('You can view the application in browser.\n\n');
 				process.stdout.write(`${bold('Local:')}            ${serverAddr}\n`);
 				process.stdout.write(`${bold('On Your Network:')}  ${localIpAddr}\n`);
 			}
-
-			showStats(stats, false);
 		});
 
 		compiler.hooks.failed.tap('CliDevPlugin', rej);
@@ -69,100 +65,81 @@ async function prodBuild(config, env) {
 	const clientWebpackConfig = await clientConfig(config, env);
 	await transformConfig(clientWebpackConfig, config, env);
 	const clientCompiler = webpack(clientWebpackConfig);
+	await runCompiler(clientCompiler);
 
-	try {
-		let stats = await runCompiler(clientCompiler);
-
-		// Timeout for plugins that work on `after-emit` event of webpack
-		await new Promise(r => setTimeout(r, 20));
-
-		return showStats(stats, true);
-	} catch (err) {
-		// eslint-disable-next-line
-		console.log(err);
-	}
+	// Timeout for plugins that work on `after-emit` event of webpack
+	await new Promise(r => setTimeout(r, 20));
 }
 
+/**
+ * @param {import('webpack').Compiler} compiler
+ */
 function runCompiler(compiler) {
-	return new Promise(res => {
+	return new Promise((res, rej) => {
 		compiler.run((err, stats) => {
-			if (err) {
-				error(err, 1);
-			}
+			if (err) rej(err);
 
-			showStats(stats, true);
+			showCompilationIssues(stats);
 
-			res(stats);
+			compiler.close(closeErr => {
+				if (closeErr) rej(closeErr);
+				res();
+			});
 		});
 	});
 }
 
-function showStats(stats, isProd) {
+/**
+ * @param {import('webpack').Stats} stats
+ */
+function showCompilationIssues(stats) {
 	if (stats) {
-		if (stats.hasErrors()) {
-			allFields(stats, 'errors')
-				.map(stripLoaderPrefix)
-				.forEach(({ message }) => error(message, isProd ? 1 : 0));
+		if (stats.hasWarnings()) {
+			allFields(stats, 'warnings').forEach(({ message }) => warn(message));
 		}
 
-		if (stats.hasWarnings()) {
-			allFields(stats, 'warnings')
-				.map(stripLoaderPrefix)
-				.forEach(({ message }) => warn(message));
+		if (stats.hasErrors()) {
+			allFields(stats, 'errors').forEach(err => {
+				throw err;
+			});
 		}
 	}
-
-	return stats;
 }
 
+/**
+ * Recursively retrieve all errors or warnings from compilation
+ *
+ * @param {import('webpack').Stats} stats
+ * @param {'warnings' | 'errors'} field
+ * @returns {import('webpack').StatsError[]}
+ */
 function allFields(stats, field, fields = [], name = null) {
 	const info = stats.toJson({
 		errors: true,
 		warnings: true,
 		errorDetails: false,
 	});
+
 	const addCompilerPrefix = msg =>
 		name ? bold(magenta(name + ': ')) + msg : msg;
-	if (field === 'errors' && stats.hasErrors()) {
+
+	if (field === 'errors') {
 		fields = fields.concat(info.errors.map(addCompilerPrefix));
-	}
-	if (field === 'warnings' && stats.hasWarnings()) {
+	} else {
 		fields = fields.concat(info.warnings.map(addCompilerPrefix));
 	}
+
 	if (stats.compilation.children) {
 		stats.compilation.children.forEach((child, index) => {
 			const name = child.name || `Child Compiler ${index + 1}`;
 			const stats = child.getStats();
-			fields = allFields(stats, field, fields, name);
+			if (field === 'errors' ? stats.hasErrors() : stats.hasWarnings()) {
+				fields = allFields(stats, field, fields, name);
+			}
 		});
 	}
+
 	return fields;
-}
-
-/** Removes all loaders from any resource identifiers found in a string */
-function stripLoaderPrefix(str) {
-	if (typeof str === 'string') {
-		str = str.replace(
-			/(?:(\()|(^|\b|@))(\.\/~|\.{0,2}\/(?:[^\s]+\/)?node_modules)\/\w+-loader(\/[^?!]+)?(\?\?[\w_.-]+|\?({[\s\S]*?})?)?!/g,
-			'$1'
-		);
-		str = str.replace(/(\.?\.?(?:\/[^/ ]+)+)\s+\(\1\)/g, '$1');
-		str = replaceAll(str, process.cwd(), '.');
-		return str;
-	}
-	return str;
-}
-
-// https://gist.github.com/developit/1a40a6fee65361d1182aaa22ab8c334c
-function replaceAll(str, find, replace) {
-	let s = '',
-		index,
-		next;
-	while (~(next = str.indexOf(find, index))) {
-		s += str.substring(index, next) + replace;
-		index = next + find.length;
-	}
-	return s + str.substring(index);
 }
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Did you add tests for your changes?**

Existing should cover

**Summary**

Refactors our error handling for better internal consistency and improves error/warning messages for users.

Previously, we quite heavily used `process.exit()` to react to any compilation errors from Webpack. While this is perfectly usable for end users, it creates a bit of a problem internally for our test suite; if we're mixing throwing errors and `process.exit()`, it becomes a bit of a challenge to ensure our builds are completing as they should. At best, it's extra boilerplate for each test that relies on completion w/out errors (test needs to now throw and we need to spy on `process.exit()`), at worst, tests are passing that shouldn't.

So, this PR looks to remove those `.exit()` calls and instead simply throw errors; these errors are still caught at the CLI root (which is how our users will interact with `preact-cli`) but we can detect from the commands themselves (`build()`, `watch()`, etc.)

Additionally, with Webpack v5 and Dev Server v4, Webpack's messages in dev are _much_ improved, removing the need for use to handle them ourselves. Here's an example from before this PR:

 Warning             |  Error
:-------------------------:|:-------------------------:
![Warning in Dev](https://user-images.githubusercontent.com/33403762/208773366-e3cfeee4-ae76-4067-bb19-93a66129c96b.png) | ![Error in Dev](https://user-images.githubusercontent.com/33403762/208773428-148fb12b-d057-4465-b470-9c434b94acff.png)

Our messages are first in both cases, with Webpack's own coming second. As you can see, while the warnings are interchangeable, in the case of errors, our messages are a bit lacking; the in-built error messaging conveniently returns the error position to the end user.

As such, I see no reason for us to continue handling warning/errors in dev, instead, let's use the (greatly improved) built-ins. I've also adopted this structure for our own messages, so in `build`, if a Webpack compilation error is thrown, it will resemble the error structure from above (module name + line of code, with the full message on the following line).

**Does this PR introduce a breaking change?**

I don't believe so
