### PR TITLE
fix: `--esm` and `--brotli` flags

### DIFF
--- a/.changeset/quiet-wombats-ring.md
+++ b/.changeset/quiet-wombats-ring.md
@@ -1,0 +1,7 @@
+---
+'preact-cli': patch
+---
+
+Fixed bug in which `--esm` was not enabled by default for production builds on v3.4.2
+
+Fix for `--brotli` overwriting assets

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -37,7 +37,7 @@ prog
 	.option('--src', 'Specify source directory', 'src')
 	.option('--dest', 'Specify output directory', 'build')
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
-	.option('--esm', 'Builds ES-2015 bundles for your code', false)
+	.option('--esm', 'Builds ES-2015 bundles for your code', true)
 	.option('--sw', 'Generate and attach a Service Worker', true)
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
 	.option('--json', 'Generate build stats for bundle analysis', false)

--- a/packages/cli/src/lib/webpack/webpack-client-config.js
+++ b/packages/cli/src/lib/webpack/webpack-client-config.js
@@ -273,7 +273,7 @@ function isProd(env) {
 	if (env.brotli) {
 		prodConfig.plugins.push(
 			new CompressionPlugin({
-				filename: '[path].br[query]',
+				filename: '[path][base].br[query]',
 				algorithm: 'brotliCompress',
 				test: /\.esm\.js$/,
 			})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfixes

**Did you add tests for your changes?**

No

**Summary**

Closes #1759

Typo in #1699 meant `--esm` was not enabled by default in production builds -- slipped past our test suite as it envokes `build()` directly, rather than calling the CLI. I may rework that.

`--brotli` hasn't worked in ages due to an incorrect file constructor. Simple fix to correct.

**Does this PR introduce a breaking change?**

No
