### PR TITLE
feat: Support proxied loaders w/ `getLoadersByName()` is user config

### DIFF
--- a/.changeset/flat-ducks-invent.md
+++ b/.changeset/flat-ducks-invent.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Support proxied loaders w/ `getLoadersByName()` method in users' `preact.config.js`

--- a/packages/cli/src/lib/webpack/transform-config.js
+++ b/packages/cli/src/lib/webpack/transform-config.js
@@ -239,11 +239,13 @@ class WebpackConfigHelpers {
 					: [{ rule, ruleIndex, loader: loaders, loaderIndex: -1 }]
 			)
 			.reduce((arr, loaders) => arr.concat(loaders), [])
-			.filter(
-				({ loader }) =>
-					(typeof loader === 'string' && loader.includes(name)) ||
-					(typeof loader.loader === 'string' && loader.loader.includes(name))
-			);
+			.filter(({ loader }) => {
+				if (typeof loader === 'string') return loader.includes(name);
+				return typeof loader.loader === 'string' &&
+					loader.loader.includes('proxy-loader')
+					? loader.options.loader.includes(name)
+					: loader.loader.includes(name);
+			});
 	}
 
 	/**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature / bugfix

**Did you add tests for your changes?**

No

**Summary**

Closes #929

If the loader is being proxied (like say `sass-loader`), we need to look a bit deeper then we normally would to get the "correct" loader.

The interface here is a bit messy though, might be a bit confusing to users *why* there's this proxy loader:

```json
[
    {
        "rule": {
            "enforce": "pre",
            "test": "\.s[ac]ss$",
            "use": [
                {
                    "loader": "/home/ryun/Projects/foobar/node_modules/preact-cli/src/lib/webpack/proxy-loader.js",
                    "options": {
                        "cwd": "/home/ryun/Projects/foobar",
                        "loader": "sass-loader",
                        "options": {
                            "sourceMap": true,
                            "sassOptions": {
                                "includePaths": [
                                    "/home/ryun/Projects/foobar/node_modules",
                                    "/home/ryun/Projects/foobar/node_modules/preact-cli/node_modules"
                                ]
                            }
                        }
                    }
                }
            ]
        },
        "ruleIndex": 2,
        "loader": {
            "loader": "/home/ryun/Projects/foobar/node_modules/preact-cli/src/lib/webpack/proxy-loader.js",
            "options": {
                "cwd": "/home/ryun/Projects/foobar",
                "loader": "sass-loader",
                "options": {
                    "sourceMap": true,
                    "sassOptions": {
                        "includePaths": [
                            "/home/ryun/Projects/foobar/node_modules",
                            "/home/ryun/Projects/foobar/node_modules/preact-cli/node_modules"
                        ]
                    }
                }
            }
        },
        "loaderIndex": 0
    }
]
```

**Does this PR introduce a breaking change?**

No