### PR TITLE
fix: Ensure devServer info message uses actual devServer config

### DIFF
--- a/.changeset/curvy-clouds-shake.md
+++ b/.changeset/curvy-clouds-shake.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fix for devServer info output possibly not matching up against devServer config

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -8,7 +8,6 @@ exports.build = async function buildCommand(src, argv) {
 	argv.src = src || argv.src;
 	// add `default:true`s, `--no-*` disables
 	argv.prerender = toBool(argv.prerender);
-	argv.production = toBool(argv.production);
 
 	let cwd = resolve(argv.cwd);
 

--- a/packages/cli/src/commands/watch.js
+++ b/packages/cli/src/commands/watch.js
@@ -9,7 +9,6 @@ exports.watch = async function watchCommand(src, argv) {
 		argv.refresh = argv.rhl;
 	}
 	argv.src = src || argv.src;
-	argv.production = false;
 	if (argv.sw) {
 		argv.sw = toBool(argv.sw);
 	}
@@ -22,9 +21,14 @@ exports.watch = async function watchCommand(src, argv) {
 	// and the current directory differ.
 	require('dotenv').config({ path: resolve(cwd, '.env') });
 
+	argv.https = toBool(process.env.HTTPS || argv.https);
+	argv.host = process.env.HOST || argv.host;
+	if (argv.host === '0.0.0.0' && process.platform === 'win32') {
+		argv.host = 'localhost';
+	}
 	argv.port = await determinePort(argv.port);
 
-	if (argv.https || process.env.HTTPS) {
+	if (argv.https) {
 		let { key, cert, cacert } = argv;
 		if (key && cert) {
 			argv.https = { key, cert, ca: cacert };

--- a/packages/cli/src/lib/webpack/run-webpack.js
+++ b/packages/cli/src/lib/webpack/run-webpack.js
@@ -23,13 +23,12 @@ async function devBuild(env) {
 
 		compiler.hooks.done.tap('CliDevPlugin', stats => {
 			let devServer = config.devServer;
-			let protocol = process.env.HTTPS || devServer.https ? 'https' : 'http';
-			let host = process.env.HOST || devServer.host || 'localhost';
-			if (host === '0.0.0.0' && process.platform === 'win32') {
-				host = 'localhost';
-			}
-			let serverAddr = `${protocol}://${host}:${bold(env.port)}`;
-			let localIpAddr = `${protocol}://${ip.address()}:${bold(env.port)}`;
+			let protocol = devServer.https ? 'https' : 'http';
+
+			let serverAddr = `${protocol}://${devServer.host}:${bold(
+				devServer.port
+			)}`;
+			let localIpAddr = `${protocol}://${ip.address()}:${bold(devServer.port)}`;
 
 			if (stats.hasErrors()) {
 				process.stdout.write(red('Build failed!\n\n'));
@@ -232,6 +231,7 @@ function stripLoaderFromModuleNames(m) {
 }
 
 module.exports = function (env, watch = false) {
+	env.production = !watch;
 	env.isProd = env.production; // shorthand
 	env.isWatch = !!watch; // use HMR?
 	env.cwd = resolve(env.cwd || process.cwd());

--- a/packages/cli/src/lib/webpack/webpack-client-config.js
+++ b/packages/cli/src/lib/webpack/webpack-client-config.js
@@ -351,7 +351,7 @@ function isDev(env) {
 			},
 			https: env.https,
 			port: env.port,
-			host: process.env.HOST || env.host || '0.0.0.0',
+			host: env.host,
 			allowedHosts: 'all',
 			historyApiFallback: true,
 			client: {

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -53,7 +53,7 @@ exports.normalizeTemplatesResponse = function (repos = []) {
 };
 
 exports.toBool = function (val) {
-	return val === void 0 || (val === 'false' ? false : val);
+	return val !== void 0 && val !== false && !/false|0/.test(val);
 };
 
 exports.esmImport = require('esm')(module);

--- a/packages/cli/tests/lib/cli.js
+++ b/packages/cli/tests/lib/cli.js
@@ -19,6 +19,7 @@ exports.build = async function (cwd, options, installNodeModules = false) {
 		src: 'src',
 		dest: 'build',
 		config: 'preact.config.js',
+		prerender: true,
 		prerenderUrls: 'prerender-urls.json',
 		'inline-css': true,
 	};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Did you add tests for your changes?**

No

**Summary**

Essentially, we are normalizing CLI options way too late, causing inconsistencies.

As the output message didn't consume `webpack.devServer`'s config, there were some situations in which the two wouldn't match up: an example of this being `HTTPS=true yarn preact watch`. We consumed `process.env.HTTPS` in the informational text, but not for the actual dev server config. The user would see an error if they tried to open the URL we provided in their browser.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Please paste the results of `preact info` here.
