### PR TITLE
Refactor: Enable Prefresh by Default

### DIFF
--- a/.changeset/lucky-lizards-drive.md
+++ b/.changeset/lucky-lizards-drive.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': major
+---
+
+HMR / the `--refresh` flag is now enabled by default in dev mode.

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -59,7 +59,7 @@ prog
 	.option('--clear', 'Clears the console when the devServer updates', true)
 	.option('--sw', 'Generate and attach a Service Worker')
 	.option('--babelConfig', 'Path to custom Babel config', '.babelrc')
-	.option('--refresh', 'Enables experimental prefresh functionality', false)
+	.option('--refresh', 'Enables HMR with Prefresh', true)
 	.option(
 		'--template',
 		'Path to custom HTML template (default "src/template.html")'

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -15,10 +15,10 @@ exports.default = {
 	'ssr-build/ssr-bundle.css': 2346,
 	'ssr-build/ssr-bundle.css.map': 3603,
 
-	'bundle.448c6.js': 21563,
-	'bundle.448c6.js.map': 86009,
-	'bundle.448c6.legacy.js': 22586,
-	'bundle.448c6.legacy.js.map': 107151,
+	'bundle.5be14.js': 21563,
+	'bundle.5be14.js.map': 86009,
+	'bundle.5be14.legacy.js': 22586,
+	'bundle.5be14.legacy.js.map': 107151,
 	'bundle.6329a.css': 1173,
 	'bundle.6329a.css.map': 2165,
 
@@ -32,12 +32,12 @@ exports.default = {
 	'preact_prerender_data.json': 11,
 	'asset-manifest.json': 1686,
 
-	'route-home.chunk.45dcd.js': 1179,
-	'route-home.chunk.45dcd.js.map': 3814,
-	'route-home.chunk.45dcd.legacy.js': 1222,
-	'route-home.chunk.45dcd.legacy.js.map': 4452,
-	'route-home.chunk.b1385.css': 838,
-	'route-home.chunk.b1385.css.map': 1406,
+	'route-home.chunk.e8f16.js': 1179,
+	'route-home.chunk.e8f16.js.map': 3814,
+	'route-home.chunk.e8f16.legacy.js': 1222,
+	'route-home.chunk.e8f16.legacy.js.map': 4452,
+	'route-home.chunk.d116e.css': 838,
+	'route-home.chunk.d116e.css.map': 1406,
 
 	'route-profile.chunk.7a48e.js': 3165,
 	'route-profile.chunk.7a48e.js.map': 12464,

--- a/packages/create-cli/tests/images/create.js
+++ b/packages/create-cli/tests/images/create.js
@@ -3,6 +3,7 @@ const path = require('path');
 exports.default = [
 	'.gitignore',
 	'package.json',
+	'preact.config.js',
 	'README.md',
 	'src/assets/favicon.ico',
 	'src/assets/icons/android-chrome-192x192.png',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Did you add tests for your changes?**

No

**Summary**

Prefresh is pretty neat and HMR is now the standard for build tooling. We should enable it by default else some might assume we don't support it.

**Does this PR introduce a breaking change?**

Yes, enables `--refresh` by default now.

Users can still disable with `--no-refresh` or `--refresh false` if they'd prefer live reload.
