### PR TITLE
ci: Cache repos fetched by gittar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,33 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x]
+
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
+      - uses: actions/cache@v3
+        id: gittar-cache
+        with:
+          path: ~/.gittar
+          key: ${{ runner.os }}-gittar
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/cache@v3
+        id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
+
       - run: yarn install --frozen-lockfile
       - name: test
         env:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

CI

**Did you add tests for your changes?**

N/A

**Summary**

We keep getting CI errors due to GitHub rate limiting Actions.

Gittar downloads a local cache and prioritizes it when it exists. We can store that in Actions, though any updates to the templates will require a manual cache clear.

**Does this PR introduce a breaking change?**

N/A
