### PR TITLE
fix: Ensure processing prerenderUrls fails build rather than warn

### DIFF
--- a/.changeset/hip-pans-visit.md
+++ b/.changeset/hip-pans-visit.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+If `--prerenderUrls` file exists on the disk, but it cannot be processed (thrown errors, incorrect format, etc), the build should error out rather than continue with a warning.

--- a/packages/cli/src/lib/webpack/render-html-plugin.js
+++ b/packages/cli/src/lib/webpack/render-html-plugin.js
@@ -5,7 +5,7 @@ const HtmlWebpackExcludeAssetsPlugin = require('html-webpack-exclude-assets-plug
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const prerender = require('./prerender');
 const createLoadManifest = require('./create-load-manifest');
-const { esmImport, tryResolveConfig, warn } = require('../../util');
+const { error, esmImport, tryResolveConfig, warn } = require('../../util');
 
 const PREACT_FALLBACK_URL = '/200.html';
 
@@ -126,11 +126,12 @@ module.exports = async function (config) {
 				if (Array.isArray(result)) {
 					pages = result;
 				}
-			} catch (error) {
-				warn(
-					`Failed to load prerenderUrls file, using default!\n${
-						config.verbose ? error.stack : error.message
-					}`
+			} catch (err) {
+				error(
+					`Failed to load prerenderUrls file!\n${
+						config.verbose ? err.stack : err.message
+					}`,
+					1
 				);
 			}
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

N/A

**Summary**

Better fix for https://github.com/preactjs/preact-www/pull/979

If the `--prerenderUrls` file exists (defaults to `/prerender-urls.json`) on disk, but for some reason cannot produce a result (wrong format, throws, etc.), this PR ensures the build fails, rather than continues w/ a warning while using the default (prerendering only `/` with no passed-in data).

**Does this PR introduce a breaking change?**

Technically yes, though it's the right change to make. It will only break builds for those that have the file on disk, but a result cannot be obtained from it. They should remove the file or fix it.
