### PR TITLE
refactor: Make TS a peer dep

### DIFF
--- a/.changeset/empty-experts-float.md
+++ b/.changeset/empty-experts-float.md
@@ -1,0 +1,9 @@
+---
+'preact-cli': minor
+---
+
+TypeScript is now an optional peer dependency, rather than a direct dependency, of `preact-cli`.
+
+If you use TypeScript in your projects (`.ts` or `.tsx`), you will need to have your own version of TypeScript installed and added to your `package.json`. This gives you greator control over the version of TypeScript used and most already have TypeScript listed as a dependency anyways.
+
+For those not using TypeScript, no change is needed, and this should make your `node_modules` directory a bit smaller (~20% w/ barebones dependency list).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -96,7 +96,6 @@
     "stack-trace": "0.0.10",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "~4.6.4",
     "update-notifier": "^5.1.0",
     "url-loader": "^4.1.1",
     "validate-npm-package-name": "^4.0.0",
@@ -133,14 +132,16 @@
     "shelljs": "^0.8.3",
     "sirv": "^1.0.11",
     "stylus": "^0.54.8",
-    "stylus-loader": "^4.3.3"
+    "stylus-loader": "^4.3.3",
+    "typescript": "~4.6.4"
   },
   "peerDependencies": {
     "less-loader": "^7.3.0",
     "preact": "*",
     "preact-render-to-string": "*",
     "sass-loader": "^10.2.0",
-    "stylus-loader": "^4.3.3"
+    "stylus-loader": "^4.3.3",
+    "typescript": "^4.6.4"
   },
   "peerDependenciesMeta": {
     "less-loader": {
@@ -150,6 +151,9 @@
       "optional": true
     },
     "stylus-loader": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Did you add tests for your changes?**

N/A

**Summary**

Makes TypeScript an optional peer dependency, rather than a direct dependency.

TS was originally added as a dependency [here](https://github.com/preactjs/preact-cli/commit/3bf3a2b68041b53cd047c6069643794a1a69f5e7#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758) as part of the TypeScript support. However, today we only rely on TS to support the TS checker plugin, which only runs if the user has a `tsconfig.json`. This makes it a perfect optional peer dependency.

As for why this is needed, it's to better address #1797. Preact has began to use very new TypeScript lib types (https://github.com/preactjs/preact/issues/4023) which necessitate using newer TypeScript releases. `preact-cli` will prioritize it's own dependencies over user-installed ones (to avoid conflicts, especially with Webpack plugin versions), so it'd be ideal if we relinquish control over TypeScript versioning entirely, leaving it up to the user.

**Does this PR introduce a breaking change?**

Nothing should break except in the case someone uses TypeScript (has a `tsconfig.json` in their project), but doesn't have TS listed as a dependency.

They should have TS listed as a dep anyhow (we do in all of our templates and it's pretty standard behavior), so I'm fine with that, even if it is a tiny breakage.