### PR TITLE
fix: Don't use `optimize-plugin`'s minify due to collisions

### DIFF
--- a/.changeset/weak-trains-pay.md
+++ b/.changeset/weak-trains-pay.md
@@ -1,0 +1,5 @@
+---
+'preact-cli': patch
+---
+
+Fix for incorrect minification in some specific circumstances. Files should now minify slightly better too.

--- a/packages/cli/src/lib/webpack/webpack-client-config.js
+++ b/packages/cli/src/lib/webpack/webpack-client-config.js
@@ -153,6 +153,7 @@ function prodBuild(config) {
 				polyfillsFilename: 'es-polyfills.js',
 				exclude: [/^sw.*\.js/, /^dom-polyfills.*\.js/],
 				modernize: false,
+				minify: false,
 				verbose: false,
 			}),
 			new SizePlugin({
@@ -166,7 +167,7 @@ function prodBuild(config) {
 			minimizer: [
 				new TerserPlugin({
 					extractComments: false,
-					test: /(sw|dom-polyfills).*\.js$/,
+					test: /\.js$/,
 					terserOptions: {
 						output: { comments: false },
 						mangle: true,

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -14,15 +14,15 @@ exports.default = {
 	'ssr-build/ssr-bundle.css': 2346,
 	'ssr-build/ssr-bundle.css.map': 3603,
 
-	'bundle.c74f5.js': 23145,
-	'bundle.c74f5.js.map': 92586,
-	'bundle.c74f5.legacy.js': 24195,
-	'bundle.c74f5.legacy.js.map': 107151,
+	'bundle.d55d3.js': 22978,
+	'bundle.d55d3.js.map': 92378,
+	'bundle.d55d3.legacy.js': 23646,
+	'bundle.d55d3.legacy.js.map': 92673,
 	'bundle.6329a.css': 1173,
 	'bundle.6329a.css.map': 2165,
 
-	'dom-polyfills.aeb97.js': 5221,
-	'dom-polyfills.aeb97.js.map': 18676,
+	'dom-polyfills.99150.js': 5221,
+	'dom-polyfills.99150.js.map': 18676,
 	'es-polyfills.js': 46419,
 
 	'favicon.ico': 15086,
@@ -30,17 +30,17 @@ exports.default = {
 	'manifest.json': 455,
 	'preact_prerender_data.json': 11,
 
-	'route-home.chunk.6c974.js': 1179,
-	'route-home.chunk.6c974.js.map': 3814,
-	'route-home.chunk.6c974.legacy.js': 1222,
-	'route-home.chunk.6c974.legacy.js.map': 4452,
+	'route-home.chunk.ede4d.js': 1179,
+	'route-home.chunk.ede4d.js.map': 3814,
+	'route-home.chunk.ede4d.legacy.js': 1222,
+	'route-home.chunk.ede4d.legacy.js.map': 3964,
 	'route-home.chunk.d116e.css': 838,
 	'route-home.chunk.d116e.css.map': 1406,
 
-	'route-profile.chunk.0401b.js': 3165,
-	'route-profile.chunk.0401b.js.map': 13170,
-	'route-profile.chunk.0401b.legacy.js': 3302,
-	'route-profile.chunk.0401b.legacy.js.map': 15845,
+	'route-profile.chunk.6856a.js': 3165,
+	'route-profile.chunk.6856a.js.map': 13170,
+	'route-profile.chunk.6856a.legacy.js': 3302,
+	'route-profile.chunk.6856a.legacy.js.map': 13200,
 };
 
 exports.prerender = {};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes

**Summary**

`optimize-plugin`'s terser setup seems to be slightly misconfigured in that bundles can be minified to have colliding declarations. Noticed it in preact-www w/ our manual chunks for the editor/repl.

**Does this PR introduce a breaking change?**

No
